### PR TITLE
User properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,20 @@ vars:
           - name: "country_code"
             value_type: "int_value"
 ```
+### Using User Properties
+
+User-scoped event properties can be assigned using the following variable configuration in your `dbt_project.yml`. The `dim_ga4__users` dimension table will be updated to include the last value seen for each user.
+```
+vars:
+  ga4:
+      user_properties:
+        - event_parameter: "page_location"
+          user_property_name: "most_recent_page_location"  
+          value_type: "string_value"
+        - event_parameter: "another_event_param"
+          user_property_name: "most_recent_param"  
+          value_type: "string_value"
+```
 
 # Connecting to BigQuery
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,19 @@ vars:
           - name: "country_code"
             value_type: "int_value"
 ```
-### Using User Properties
+### Using User Properties (Optional)
 
 User-scoped event properties can be assigned using the following variable configuration in your `dbt_project.yml`. The `dim_ga4__users` dimension table will be updated to include the last value seen for each user.
+
+```
+user_properties:
+  - event_parameter: "[your event parameter]"
+    user_propertyname: "[a unique name for the user property]"
+    value_type: "[one of string_value|int_value|float_value|double_value]"
+```
+
+For example: 
+
 ```
 vars:
   ga4:

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
 # TODO
 
 - add variable to filter out events with `debug_mode = true` - Don't see any in BQ, are they exported? 
-- bring user properties into `dim_ga4__users` (variable containing a list of user properties?)
+- allow project user to define which event parameter are user propertes and bring them into `dim_ga4__users` (variable containing a list of user properties?)
 - mechanism to take in an array variable listing custom events and output 1 model per event (is this possible?)
 - How to handle user_id vs. client_id?
 - move common event params to `base_ga4__events`

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,7 @@
 
 # TODO
 
+- Add a lookback window variable for user dimensions. it may be overly expensive to scan ALL events looking for first/last occurances of event parameters. 
 - add variable to filter out events with `debug_mode = true` - Don't see any in BQ, are they exported? 
 - mechanism to take in an array variable listing custom events and output 1 model per event (is this possible?)
 - How to handle user_id vs. client_id?

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,6 @@
 # TODO
 
 - add variable to filter out events with `debug_mode = true` - Don't see any in BQ, are they exported? 
-- allow project user to define which event parameter are user propertes and bring them into `dim_ga4__users` (variable containing a list of user properties?)
 - mechanism to take in an array variable listing custom events and output 1 model per event (is this possible?)
 - How to handle user_id vs. client_id?
 - move common event params to `base_ga4__events`

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -20,6 +20,15 @@ clean-targets:         # directories to be removed by `dbt clean`
 #    dataset: "your_dataset"
 #    start_date: "20210120" # Defines the earliest GA4 _TABLE_SUFFIX to load into base events model. This is a reasonable default for the GA4 obfuscated dataset
 
+# User Properties
+# User properties can be assigned using the following variable configuration in your dbt_project.yml
+#      user_properties:
+#        - name: "my_event_param_1"
+#          value_type: "string_value"
+#        - name: "my_event_param_2"
+#          value_type: "string_value"
+
+# Custom parameters
 # custom parameters are registered by creating a var matching the event name where the custom parameter occurs
 # and providing the name, matching the parameters name
 # and matching the value_type to the type of column in BigQuery (string_value, int_value, float_value, double_value)

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -21,11 +21,14 @@ clean-targets:         # directories to be removed by `dbt clean`
 #    start_date: "20210120" # Defines the earliest GA4 _TABLE_SUFFIX to load into base events model. This is a reasonable default for the GA4 obfuscated dataset
 
 # User Properties
-# User properties can be assigned using the following variable configuration in your dbt_project.yml
+# User-scoped event properties can be assigned using the following variable configuration in your dbt_project.yml
+# The dim_ga4__users dimension table will be updated to include the last value seen for each user
 #      user_properties:
-#        - name: "my_event_param_1"
+#        - event_parameter: "page_location"
+#          user_property_name: "most_recent_page_location"  
 #          value_type: "string_value"
-#        - name: "my_event_param_2"
+#        - event_parameter: "another_event_param"
+#          user_property_name: "most_recent_param"  
 #          value_type: "string_value"
 
 # Custom parameters

--- a/models/marts/core/dim_ga4__users.sql
+++ b/models/marts/core/dim_ga4__users.sql
@@ -43,5 +43,6 @@ include_first_last_page_views as (
 
 select * from include_first_last_page_views
 {% if var('user_properties', false) %}
+-- If custom user properties have been assigned as variables, join them on the client ID
 left join {{ref('stg_ga4__user_properties')}} using (client_id)
 {% endif %}

--- a/models/marts/core/dim_ga4__users.sql
+++ b/models/marts/core/dim_ga4__users.sql
@@ -42,3 +42,6 @@ include_first_last_page_views as (
 )
 
 select * from include_first_last_page_views
+{% if var('user_properties', false) %}
+left join {{ref('stg_ga4__user_properties')}} using (client_id)
+{% endif %}

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -33,3 +33,9 @@ models:
           - unique
   - name: stg_ga4__event_scroll
     description: Staging model containing only 'scroll' events. Includes the 'percent_scrolled' parameter.
+  - name: stg_ga4__user_properties
+    description: Optional model that will pull out the most recent instance of a particular event parameter for each client_id. Later used in the dim_ga4__users dimension table.
+    columns:
+      - name: client_id
+        tests:
+          - unique  

--- a/models/staging/ga4/stg_ga4__user_properties.sql
+++ b/models/staging/ga4/stg_ga4__user_properties.sql
@@ -2,7 +2,6 @@
   enabled = true if var('user_properties', false) != false else false
 ) }}
 
--- TODO update this to create 1 CTE per user property that pulls only events with non-null values for that event parameters. Join them at the end. 
 
 with unnest_user_properties as
 (
@@ -13,15 +12,55 @@ with unnest_user_properties as
             ,{{ unnest_key('event_params',  up.event_parameter ,  up.value_type ) }}
         {% endfor %}
     from {{ref('stg_ga4__events')}}
+)
+-- create 1 CTE per user property that pulls only events with non-null values for that event parameters. 
+-- Find the most recent property for that user and join later
+{% for up in var('user_properties', []) %}
+,non_null_{{up.event_parameter}} as
+(
+    select
+        client_id,
+        event_timestamp,
+        {{up.event_parameter}}
+    from unnest_user_properties
+    where
+        {{up.event_parameter}} is not null
 ),
-find_last_value as
+last_value_{{up.event_parameter}} as 
+(
+    select
+        client_id,
+        LAST_VALUE({{ up.event_parameter }}) OVER (PARTITION BY client_id ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {{up.user_property_name}}
+    from non_null_{{up.event_parameter}}
+),
+last_value_{{up.event_parameter}}_grouped as 
+(
+    select
+        client_id,
+        {{up.user_property_name}}
+    from last_value_{{up.event_parameter}}
+    group by client_id, {{up.user_property_name}}
+)
+{% endfor %}
+,
+client_ids as 
+(
+    select distinct
+        client_id
+    from unnest_user_properties
+),
+join_properties as 
 (
     select
         client_id
         {% for up in var('user_properties', []) %}
-            ,LAST_VALUE({{ up.event_parameter }}) OVER (PARTITION BY client_id ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {{up.user_property_name}}
+        ,last_value_{{up.event_parameter}}_grouped.{{up.user_property_name}}
         {% endfor %}
-    from unnest_user_properties
+    from client_ids
+    {% for up in var('user_properties', []) %}
+    left join last_value_{{up.event_parameter}}_grouped using (client_id)
+    {% endfor %}
 )
 
-select distinct * from find_last_value
+
+select distinct * from join_properties

--- a/models/staging/ga4/stg_ga4__user_properties.sql
+++ b/models/staging/ga4/stg_ga4__user_properties.sql
@@ -2,6 +2,7 @@
   enabled = true if var('user_properties', false) != false else false
 ) }}
 
+-- TODO update this to create 1 CTE per user property that pulls only events with non-null values for that event parameters. Join them at the end. 
 
 with unnest_user_properties as
 (

--- a/models/staging/ga4/stg_ga4__user_properties.sql
+++ b/models/staging/ga4/stg_ga4__user_properties.sql
@@ -1,5 +1,5 @@
 {{ config(
-  enabled = true if var('user_properties') else false 
+  enabled = true if var('user_properties', false) != false else false
 ) }}
 
 
@@ -8,7 +8,7 @@ with unnest_user_properties as
     select 
         client_id,
         event_timestamp
-        {% for up in var('user_properties') %}
+        {% for up in var('user_properties', []) %}
             ,{{ unnest_key('event_params',  up.event_parameter ,  up.value_type ) }}
         {% endfor %}
     from {{ref('stg_ga4__events')}}
@@ -17,7 +17,7 @@ find_last_value as
 (
     select
         client_id
-        {% for up in var('user_properties') %}
+        {% for up in var('user_properties', []) %}
             ,LAST_VALUE({{ up.event_parameter }}) OVER (PARTITION BY client_id ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {{up.user_property_name}}
         {% endfor %}
     from unnest_user_properties

--- a/models/staging/ga4/stg_ga4__user_properties.sql
+++ b/models/staging/ga4/stg_ga4__user_properties.sql
@@ -1,0 +1,26 @@
+{{ config(
+  enabled = true if var('user_properties') else false 
+) }}
+
+
+with unnest_user_properties as
+(
+    select 
+        client_id,
+        event_timestamp
+        {% for up in var('user_properties') %}
+            ,{{ unnest_key('event_params',  up.event_parameter ,  up.value_type ) }}
+        {% endfor %}
+    from {{ref('stg_ga4__events')}}
+),
+find_last_value as
+(
+    select
+        client_id
+        {% for up in var('user_properties') %}
+            ,LAST_VALUE({{ up.event_parameter }}) OVER (PARTITION BY client_id ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {{up.user_property_name}}
+        {% endfor %}
+    from unnest_user_properties
+)
+
+select distinct * from find_last_value


### PR DESCRIPTION
## Description & motivation
GA4 admins are able to assign any event param as a 'user dimension' in the GA4 interface. This PR provides equivalent functionality from within BigQuery by assigning event params as user-scoped dimensions. A new model, `stg_ga4__user_properties` finds the latest instance of an event parameter for each `client_id` 

## Checklist
- [ x] I have verified that these changes work locally
- [ x] I have updated the README.md (if applicable)
- [ x] I have added tests & descriptions to my models (and macros if applicable)