### PR TITLE
Prefixed macros with ga4. to simplify replacing models in local project

### DIFF
--- a/macros/stage_custom_parameters.sql
+++ b/macros/stage_custom_parameters.sql
@@ -1,6 +1,6 @@
 {% macro stage_custom_parameters(custom_parameters ) %}
     {% for cp in custom_parameters %}
-        ,{{ unnest_key('event_params',  cp.name ,  cp.value_type ) }}
+        ,{{ ga4.unnest_key('event_params',  cp.name ,  cp.value_type ) }}
     {% endfor %}
 {% endmacro %}
 

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -88,14 +88,14 @@ renamed as (
         platform,
         ecommerce,
         items,
-        {{ unnest_key('event_params', 'ga_session_id', 'int_value') }},
-        {{ unnest_key('event_params', 'page_location') }},
-        {{ unnest_key('event_params', 'ga_session_number',  'int_value') }},
-        {{ unnest_key('event_params', 'session_engaged', 'int_value') }},
-        {{ unnest_key('event_params', 'page_title') }},
-        {{ unnest_key('event_params', 'page_referrer') }},
-        {{ unnest_key('event_params', 'source') }},
-        {{ unnest_key('event_params', 'medium') }},
+        {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value') }},
+        {{ ga4.unnest_key('event_params', 'page_location') }},
+        {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value') }},
+        {{ ga4.unnest_key('event_params', 'session_engaged', 'int_value') }},
+        {{ ga4.unnest_key('event_params', 'page_title') }},
+        {{ ga4.unnest_key('event_params', 'page_referrer') }},
+        {{ ga4.unnest_key('event_params', 'source') }},
+        {{ ga4.unnest_key('event_params', 'medium') }},
         CASE 
             WHEN event_name = 'page_view' THEN 1
             ELSE 0

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -54,14 +54,14 @@ renamed as (
         platform,
         ecommerce,
         items,
-        {{ unnest_key('event_params', 'ga_session_id', 'int_value') }},
-        {{ unnest_key('event_params', 'page_location') }},
-        {{ unnest_key('event_params', 'ga_session_number',  'int_value') }},
-        {{ unnest_key('event_params', 'session_engaged', 'int_value') }},
-        {{ unnest_key('event_params', 'page_title') }},
-        {{ unnest_key('event_params', 'page_referrer') }},
-        {{ unnest_key('event_params', 'source') }},
-        {{ unnest_key('event_params', 'medium') }},
+        {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value') }},
+        {{ ga4.unnest_key('event_params', 'page_location') }},
+        {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value') }},
+        {{ ga4.unnest_key('event_params', 'session_engaged', 'int_value') }},
+        {{ ga4.unnest_key('event_params', 'page_title') }},
+        {{ ga4.unnest_key('event_params', 'page_referrer') }},
+        {{ ga4.unnest_key('event_params', 'source') }},
+        {{ ga4.unnest_key('event_params', 'medium') }},
         CASE 
             WHEN event_name = 'page_view' THEN 1
             ELSE 0

--- a/models/staging/ga4/events/stg_ga4__event_click.sql
+++ b/models/staging/ga4/events/stg_ga4__event_click.sql
@@ -2,17 +2,17 @@
  
  with click_with_params as (
    select *,
-      {{ unnest_key('event_params', 'entrances',  'int_value') }},
-      {{ unnest_key('event_params', 'outbound') }},
-      {{ unnest_key('event_params', 'link_classes') }},
-      {{ unnest_key('event_params', 'link_domain') }},
-      {{ unnest_key('event_params', 'link_url') }},
-      {{ unnest_key('event_params', 'click_element') }},
-      {{ unnest_key('event_params', 'link_id') }},
-      {{ unnest_key('event_params', 'click_region') }},
-      {{ unnest_key('event_params', 'click_tag_name') }},
-      {{ unnest_key('event_params', 'click_url') }},
-      {{ unnest_key('event_params', 'file_name') }}
+      {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
+      {{ ga4.unnest_key('event_params', 'outbound') }},
+      {{ ga4.unnest_key('event_params', 'link_classes') }},
+      {{ ga4.unnest_key('event_params', 'link_domain') }},
+      {{ ga4.unnest_key('event_params', 'link_url') }},
+      {{ ga4.unnest_key('event_params', 'click_element') }},
+      {{ ga4.unnest_key('event_params', 'link_id') }},
+      {{ ga4.unnest_key('event_params', 'click_region') }},
+      {{ ga4.unnest_key('event_params', 'click_tag_name') }},
+      {{ ga4.unnest_key('event_params', 'click_url') }},
+      {{ ga4.unnest_key('event_params', 'file_name') }}
       {% if var("click_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("click_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_file_download.sql
+++ b/models/staging/ga4/events/stg_ga4__event_file_download.sql
@@ -2,15 +2,15 @@
  
  with event_with_params as (
    select *,
-      {{ unnest_key('event_params', 'entrances',  'int_value') }},
-      {{ unnest_key('event_params', 'value', 'float_value') }},
-      {{ unnest_key('event_params', 'file_extension') }},
-      {{ unnest_key('event_params', 'file_name') }},
-      {{ unnest_key('event_params', 'link_classes') }},
-      {{ unnest_key('event_params', 'link_domain') }},
-      {{ unnest_key('event_params', 'link_id') }},
-      {{ unnest_key('event_params', 'link_text') }},
-      {{ unnest_key('event_params', 'link_url') }}
+      {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
+      {{ ga4.unnest_key('event_params', 'value', 'float_value') }},
+      {{ ga4.unnest_key('event_params', 'file_extension') }},
+      {{ ga4.unnest_key('event_params', 'file_name') }},
+      {{ ga4.unnest_key('event_params', 'link_classes') }},
+      {{ ga4.unnest_key('event_params', 'link_domain') }},
+      {{ ga4.unnest_key('event_params', 'link_id') }},
+      {{ ga4.unnest_key('event_params', 'link_text') }},
+      {{ ga4.unnest_key('event_params', 'link_url') }}
       {% if var("file_download_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("file_download_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_first_visit.sql
+++ b/models/staging/ga4/events/stg_ga4__event_first_visit.sql
@@ -3,7 +3,7 @@
 with first_visit_with_params as (
  select 
     *,
-    {{ unnest_key('event_params', 'page_location', 'string_value', 'landing_page') }} 
+    {{ ga4.unnest_key('event_params', 'page_location', 'string_value', 'landing_page') }} 
       {% if var("first_visit_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("first_visit_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -1,7 +1,7 @@
  with page_view_with_params as (
    select *,
-      {{ unnest_key('event_params', 'entrances',  'int_value') }},
-      {{ unnest_key('event_params', 'value', 'float_value') }}
+      {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
+      {{ ga4.unnest_key('event_params', 'value', 'float_value') }}
       {% if var("page_view_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("page_view_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_purchase.sql
+++ b/models/staging/ga4/events/stg_ga4__event_purchase.sql
@@ -1,10 +1,10 @@
  with purchase_with_params as (
    select *,
-      {{ unnest_key('event_params', 'coupon') }},
-      {{ unnest_key('event_params', 'transaction_id') }},
-      {{ unnest_key('event_params', 'currency') }},
-      {{ unnest_key('event_params', 'payment_type') }},
-      {{ unnest_key('event_params', 'value', 'float_value') }}
+      {{ ga4.unnest_key('event_params', 'coupon') }},
+      {{ ga4.unnest_key('event_params', 'transaction_id') }},
+      {{ ga4.unnest_key('event_params', 'currency') }},
+      {{ ga4.unnest_key('event_params', 'payment_type') }},
+      {{ ga4.unnest_key('event_params', 'value', 'float_value') }}
       {% if var("purchase_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("purchase_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_scroll.sql
+++ b/models/staging/ga4/events/stg_ga4__event_scroll.sql
@@ -1,6 +1,6 @@
  with scroll_with_params as (
    select *,
-      {{ unnest_key('event_params', 'percent_scrolled', 'int_value') }}
+      {{ ga4.unnest_key('event_params', 'percent_scrolled', 'int_value') }}
       {% if var("scroll_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("scroll_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_session_start.sql
+++ b/models/staging/ga4/events/stg_ga4__event_session_start.sql
@@ -1,7 +1,7 @@
  with session_start_with_params as (
    select *,
-      {{ unnest_key('event_params', 'entrances',  'int_value') }},
-      {{ unnest_key('event_params', 'value', 'float_value') }}
+      {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
+      {{ ga4.unnest_key('event_params', 'value', 'float_value') }}
       {% if var("session_start_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("session_start_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_user_engagement.sql
+++ b/models/staging/ga4/events/stg_ga4__event_user_engagement.sql
@@ -2,7 +2,7 @@
  
  with user_engagement_with_params as (
    select *,
-      {{ unnest_key('event_params', 'engagement_time_msec', 'int_value') }}
+      {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }}
       {% if var("user_engagement_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("user_engagement_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_video_complete.sql
+++ b/models/staging/ga4/events/stg_ga4__event_video_complete.sql
@@ -3,13 +3,13 @@
  
  with video_complete_with_params as (
    select *,
-      {{ unnest_key('event_params', 'video_current_time', 'int_value') }},
-      {{ unnest_key('event_params', 'video_duration', 'int_value') }},
-      {{ unnest_key('event_params', 'video_percent', 'int_value') }},
-      {{ unnest_key('event_params', 'video_url') }},
-      {{ unnest_key('event_params', 'video_provider') }},
-      {{ unnest_key('event_params', 'vide_title') }},
-      {{ unnest_key('event_params', 'visible') }}
+      {{ ga4.unnest_key('event_params', 'video_current_time', 'int_value') }},
+      {{ ga4.unnest_key('event_params', 'video_duration', 'int_value') }},
+      {{ ga4.unnest_key('event_params', 'video_percent', 'int_value') }},
+      {{ ga4.unnest_key('event_params', 'video_url') }},
+      {{ ga4.unnest_key('event_params', 'video_provider') }},
+      {{ ga4.unnest_key('event_params', 'vide_title') }},
+      {{ ga4.unnest_key('event_params', 'visible') }}
       {% if var("video_complete_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("video_complete_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_video_start.sql
+++ b/models/staging/ga4/events/stg_ga4__event_video_start.sql
@@ -3,13 +3,13 @@
  
  with video_start_with_params as (
    select *,
-      {{ unnest_key('event_params', 'video_current_time', 'int_value') }},
-      {{ unnest_key('event_params', 'video_duration', 'int_value') }},
-      {{ unnest_key('event_params', 'video_percent', 'int_value') }},
-      {{ unnest_key('event_params', 'video_url') }},
-      {{ unnest_key('event_params', 'video_provider') }},
-      {{ unnest_key('event_params', 'vide_title') }},
-      {{ unnest_key('event_params', 'visible') }}
+      {{ ga4.unnest_key('event_params', 'video_current_time', 'int_value') }},
+      {{ ga4.unnest_key('event_params', 'video_duration', 'int_value') }},
+      {{ ga4.unnest_key('event_params', 'video_percent', 'int_value') }},
+      {{ ga4.unnest_key('event_params', 'video_url') }},
+      {{ ga4.unnest_key('event_params', 'video_provider') }},
+      {{ ga4.unnest_key('event_params', 'vide_title') }},
+      {{ ga4.unnest_key('event_params', 'visible') }}
       {% if var("video_start_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("video_start_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/events/stg_ga4__event_view_search_results.sql
+++ b/models/staging/ga4/events/stg_ga4__event_view_search_results.sql
@@ -2,9 +2,9 @@
  
  with event_with_params as (
    select *,
-      {{ unnest_key('event_params', 'entrances',  'int_value') }},
-      {{ unnest_key('event_params', 'search_term') }},
-      {{ unnest_key('event_params', 'unique_search_term') }}
+      {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
+      {{ ga4.unnest_key('event_params', 'search_term') }},
+      {{ ga4.unnest_key('event_params', 'unique_search_term') }}
       {% if var("view_search_results_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("view_search_results_custom_parameters") )}}
       {% endif %}

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -11,7 +11,7 @@ with session_events as (
 set_default_channel_grouping as (
     select
         *,
-        {{default_channel_grouping('source','medium','source_category')}} as default_channel_grouping
+        {{ga4.default_channel_grouping('source','medium','source_category')}} as default_channel_grouping
     from session_events
 ),
 session_source as (

--- a/models/staging/ga4/stg_ga4__user_properties.sql
+++ b/models/staging/ga4/stg_ga4__user_properties.sql
@@ -9,7 +9,7 @@ with unnest_user_properties as
         client_id,
         event_timestamp
         {% for up in var('user_properties', []) %}
-            ,{{ unnest_key('event_params',  up.event_parameter ,  up.value_type ) }}
+            ,{{ ga4.unnest_key('event_params',  up.event_parameter ,  up.value_type ) }}
         {% endfor %}
     from {{ref('stg_ga4__events')}}
 )


### PR DESCRIPTION
## Description & motivation
When using package macros outside the package, you need to prefix the macro with the package name. In our case, `ga4.unnest_key( ...`. 

The macros work the same way with or without the prefix within the package so this isn't strictly necessary, but it makes it faster and easier to copy and replace a model.

We should make it a coding standard to prefix all of our macros with the package name going forward.

## Checklist
- [ y] I have verified that these changes work locally
- [ n/a] I have updated the README.md (if applicable)
- [n/a ] I have added tests & descriptions to my models (and macros if applicable)