### PR TITLE
change materialization of user models to 'table'

### DIFF
--- a/models/staging/ga4/stg_ga4__user_properties.sql
+++ b/models/staging/ga4/stg_ga4__user_properties.sql
@@ -1,5 +1,6 @@
 {{ config(
-  enabled = true if var('user_properties', false) != false else false
+  enabled = true if var('user_properties', false) != false else false,
+  materialized = "table"
 ) }}
 
 

--- a/models/staging/ga4/stg_ga4__users_first_last_events.sql
+++ b/models/staging/ga4/stg_ga4__users_first_last_events.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = "table")
+}}
+
 with first_last_event as (
     select
         client_id,

--- a/models/staging/ga4/stg_ga4__users_first_last_pageviews.sql
+++ b/models/staging/ga4/stg_ga4__users_first_last_pageviews.sql
@@ -1,3 +1,7 @@
+{{
+    config(materialized = "table")
+}}
+
 with page_views_first_last as (
     select
         client_id,


### PR DESCRIPTION
Related to #22, solves bigquery query planning issues by materializing complex models as tables. likely due to a large number of window functions being joined in from multiple models.

Nice short term fix, but in the long term I'd like to get smarter about what makes those queries so complex for BigQuery. 


## Checklist
- [x ] I have verified that these changes work locally
- [na ] I have updated the README.md (if applicable)
- [na ] I have added tests & descriptions to my models (and macros if applicable)