### PR TITLE
Additional pageview dimensions

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,6 @@
 
 # TODO
 
-- Add 'previous page' to the pageviews model. (See https://www.ga4bigquery.com/page-tracking-dimensions-metrics-ga4/)
-- Add 'page path level 1, 2, 3 etc' to the pageviews model (See https://www.ga4bigquery.com/page-tracking-dimensions-metrics-ga4/)
 - Add a lookback window variable for user dimensions. it may be overly expensive to scan ALL events looking for first/last occurances of event parameters. 
 - Add common date dimension transformations (See https://www.ga4bigquery.com/date-and-time-dimensions-metrics-ga4/)
 - mechanism to take in an array variable listing custom events and output 1 model per event (is this possible?)

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -1,7 +1,13 @@
  with page_view_with_params as (
    select *,
       {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
-      {{ ga4.unnest_key('event_params', 'value', 'float_value') }}
+      {{ ga4.unnest_key('event_params', 'value', 'float_value') }},
+      lag(page_location, 1) over (partition by (session_key) order by event_timestamp asc) as previous_page_location_in_session,
+      case when split(split(page_location,'/')[safe_ordinal(4)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(4)],'?')[safe_ordinal(1)]) end as pagepath_level_1,
+      case when split(split(page_location,'/')[safe_ordinal(5)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(5)],'?')[safe_ordinal(1)]) end as pagepath_level_2,
+      case when split(split(page_location,'/')[safe_ordinal(6)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(6)],'?')[safe_ordinal(1)]) end as pagepath_level_3,
+      case when split(split(page_location,'/')[safe_ordinal(7)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(7)],'?')[safe_ordinal(1)]) end as pagepath_level_4,
+
       {% if var("page_view_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("page_view_custom_parameters") )}}
       {% endif %}
@@ -11,7 +17,7 @@
 first_last_pageview_session as (
   select * from {{ref('stg_ga4__sessions_first_last_pageviews')}}
 ),
--- Determine the session's first pageview pageview based on event_timestamp. This is redundant with the 'entrances' int value, but calculated in the warehouse so a bit more transparent in how it operates. 
+-- Determine the session's first pageview based on event_timestamp. This is redundant with the 'entrances' int value, but calculated in the warehouse so a bit more transparent in how it operates. 
 first_pageview_joined as (
   select 
     page_view_with_params.*,

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -2,43 +2,27 @@
    select *,
       {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
       {{ ga4.unnest_key('event_params', 'value', 'float_value') }},
-      lag(page_location, 1) over (partition by (session_key) order by event_timestamp asc) as previous_page_location_in_session,
+      lag(page_location, 1) over (partition by (session_key) order by event_timestamp asc) as session_previous_page,
       case when split(split(page_location,'/')[safe_ordinal(4)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(4)],'?')[safe_ordinal(1)]) end as pagepath_level_1,
       case when split(split(page_location,'/')[safe_ordinal(5)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(5)],'?')[safe_ordinal(1)]) end as pagepath_level_2,
       case when split(split(page_location,'/')[safe_ordinal(6)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(6)],'?')[safe_ordinal(1)]) end as pagepath_level_3,
       case when split(split(page_location,'/')[safe_ordinal(7)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(7)],'?')[safe_ordinal(1)]) end as pagepath_level_4,
-
       {% if var("page_view_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("page_view_custom_parameters") )}}
       {% endif %}
  from {{ref('stg_ga4__events')}}    
  where event_name = 'page_view'
 ),
-first_last_pageview_session as (
-  select * from {{ref('stg_ga4__sessions_first_last_pageviews')}}
-),
--- Determine the session's first pageview based on event_timestamp. This is redundant with the 'entrances' int value, but calculated in the warehouse so a bit more transparent in how it operates. 
-first_pageview_joined as (
+last_pageview_joined as (
   select 
     page_view_with_params.*,
     case
-      when first_last_pageview_session.first_page_view_event_key is null then FALSE
-      else TRUE
-    end as is_entrance
+      when first_last_pageview_session.last_page_view_event_key is null then null
+      else 1
+    end as exits
   from page_view_with_params
-    left join first_last_pageview_session
-      on page_view_with_params.event_key = first_last_pageview_session.first_page_view_event_key
-),
-last_pageview_joined as (
-  select 
-    first_pageview_joined.*,
-    case
-      when first_last_pageview_session.last_page_view_event_key is null then FALSE
-      else TRUE
-    end as is_exit
-  from first_pageview_joined
-    left join first_last_pageview_session
-      on first_pageview_joined.event_key = first_last_pageview_session.last_page_view_event_key
+    left join {{ref('stg_ga4__sessions_first_last_pageviews')}} first_last_pageview_session
+      on page_view_with_params.event_key = first_last_pageview_session.last_page_view_event_key
 )
 
 select * from last_pageview_joined

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -9,6 +9,10 @@ models:
     description: This model pivots the query string parameters contained within the event's page_location field to become rows. Each row is a single parameter/value combination contained in a single event's query string.
   - name: stg_ga4__event_page_view
     description: GA4 events filtered to only show 'page_view' events. Pivots common event parameters into separate columns. Identifies the first and last pageview in the 'is_entrance' and 'is_exit' columns. 
+    columns: 
+      - name: page_location
+        tests:
+          - not_null
   - name: stg_ga4__event_session_start
     description: GA4 events filtered to only show 'session_start' events. Pivots common event parameters into separate columns. 
   - name: stg_ga4__event_purchase


### PR DESCRIPTION
## Description & motivation
Added pageview-level dimensions: 
- `session_previous_pageview` which looks at the previous pageview in the session
- `pagepath_level_X` which splits the page location by `/` and pulls out the path
- `exits` calculates if page was exit page
- removed `is_entrance` which was redundant with `entrances`

Inspiration from https://www.ga4bigquery.com/page-tracking-dimensions-metrics-ga4/

## Checklist
- [x ] I have verified that these changes work locally
- [ x] I have updated the README.md (if applicable)
- [x ] I have added tests & descriptions to my models (and macros if applicable)