### PR TITLE
Adding sum of engagement time as a session-level fact

### DIFF
--- a/models/marts/core/fct_ga4__sessions.sql
+++ b/models/marts/core/fct_ga4__sessions.sql
@@ -9,7 +9,8 @@ with session_metrics as
         min(event_timestamp) as session_start_timestamp,
         countif(event_name = 'page_view') as count_page_views,
         sum(event_value_in_usd) as sum_event_value_in_usd,
-        ifnull(max(session_engaged), 0) as session_engaged
+        ifnull(max(session_engaged), 0) as session_engaged,
+        sum(engagement_time_msec) as sum_engagement_time_msec
     from {{ref('stg_ga4__events')}}
     group by 1,2
 )

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -92,6 +92,7 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'page_location') }},
         {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value') }},
         {{ ga4.unnest_key('event_params', 'session_engaged', 'int_value') }},
+        {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_title') }},
         {{ ga4.unnest_key('event_params', 'page_referrer') }},
         {{ ga4.unnest_key('event_params', 'source') }},

--- a/models/staging/ga4/events/stg_ga4__event_user_engagement.sql
+++ b/models/staging/ga4/events/stg_ga4__event_user_engagement.sql
@@ -2,7 +2,6 @@
  
  with user_engagement_with_params as (
    select *,
-      {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }}
       {% if var("user_engagement_custom_parameters", "none") != "none" %}
         {{ stage_custom_parameters( var("user_engagement_custom_parameters") )}}
       {% endif %}


### PR DESCRIPTION
## Description & motivation
Added sum of engagement_time_msec to the session fact table. 

## Checklist
- [x ] I have verified that these changes work locally
- [ na] I have updated the README.md (if applicable)
- [ na] I have added tests & descriptions to my models (and macros if applicable)