### PR TITLE
add campaign and improve sessions traffic sources model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Features include:
 | stg_ga4__event_to_query_string_params | Mapping between each event and any query parameters & values that were contained in the event's `page_location` field |
 | stg_ga4__user_properties | Finds the most recent occurance of specific event_params and assigns them to a user's client_id. User properties are specified as variables (see documentation below) |
 | stg_ga4__session_conversions | Produces session-grouped event counts for a configurable list of event names (see documentation below) |
-| stg_ga4__sessions_traffic_sources | Finds the source, medium, and default channel grouping for each session |
+| stg_ga4__sessions_traffic_sources | Finds the first source, medium, campaign and default channel grouping for each session |
 | dim_ga4__users | Dimension table for users which contains attributes such as first and last page viewed. | 
 | dim_ga4__sessions | Dimension table for sessions which contains useful attributes such as geography, device information, and campaign data |
 

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -10,7 +10,7 @@ with session_start_dims as (
         geo,
         device,
         row_number() over (partition by session_key order by session_event_number asc) as row_num
-    from {{ref("stg_ga4__event_session_start")}}
+    from {{ref('stg_ga4__event_session_start')}}
 ),
 -- Arbitrarily pull the first session_start event to remove duplicates
 remove_dupes as 
@@ -23,6 +23,7 @@ join_traffic_source as (
         remove_dupes.*,
         session_source as source,
         session_medium as medium,
+        session_campaign as campaign,
         session_default_channel_grouping as default_channel_grouping
     from remove_dupes
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -97,6 +97,7 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'page_referrer') }},
         {{ ga4.unnest_key('event_params', 'source') }},
         {{ ga4.unnest_key('event_params', 'medium') }},
+        {{ ga4.unnest_key('event_params', 'campaign') }},
         CASE 
             WHEN event_name = 'page_view' THEN 1
             ELSE 0

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -63,6 +63,7 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'page_referrer') }},
         {{ ga4.unnest_key('event_params', 'source') }},
         {{ ga4.unnest_key('event_params', 'medium') }},
+        {{ ga4.unnest_key('event_params', 'campaign') }},
         CASE 
             WHEN event_name = 'page_view' THEN 1
             ELSE 0

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -53,7 +53,13 @@ models:
           - unique
       - name: session_source
         description: source value of the first event of the session after session_start and first_visit
+        tests:
+          - not_null
       - name: session_medium
         description: medium value of the first event of the session after session_start and first_visit
+        tests:
+          - not_null
       - name: session_campaign
         description: campaign value of the first event of the session after session_start and first_visit
+        tests:
+          - not_null

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -46,7 +46,7 @@ models:
   - name: stg_ga4__session_conversions
     description: Optional model that counts the number of events listed in the 'conversion_events' var. Aggregated by session_key.
   - name: stg_ga4__sessions_traffic_sources
-    description: Optional model that finds the first session source, medium and campaign and adds the default channel grouping information. Aggregated by session_key.
+    description: Finds the first session source, medium and campaign and adds the default channel grouping information. Aggregated by session_key.
     columns:
       - name: session_key
         tests:

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -45,3 +45,15 @@ models:
           - unique  
   - name: stg_ga4__session_conversions
     description: Optional model that counts the number of events listed in the 'conversion_events' var. Aggregated by session_key.
+  - name: stg_ga4__sessions_traffic_sources
+    description: Optional model that finds the first session source, medium and campaign and adds the default channel grouping information. Aggregated by session_key.
+    columns:
+      - name: session_key
+        tests:
+          - unique
+      - name: session_source
+        description: source value of the first event of the session after session_start and first_visit
+      - name: session_medium
+        description: medium value of the first event of the session after session_start and first_visit
+      - name: session_campaign
+        description: campaign value of the first event of the session after session_start and first_visit

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -4,9 +4,13 @@ with session_events as (
         event_timestamp,
         lower(source) as source,
         medium,
+        campaign,
         source_category
     from {{ref('stg_ga4__events')}}
     left join {{ref('ga4_source_categories')}} using (source)
+    --exclude the events session_start and first_visit because they are triggered first but never contain source, medium, campaign values
+    where not ( event_name = "session_start" or event_name = "first_visit")
+    and session_key is not null
    ),
 set_default_channel_grouping as (
     select
@@ -17,8 +21,22 @@ set_default_channel_grouping as (
 session_source as (
     select    
         session_key,
-        FIRST_VALUE(source) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS session_source,
-        FIRST_VALUE(medium) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS session_medium,
+
+        (case
+          when FIRST_VALUE(source) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) is null then "(direct)"
+          else FIRST_VALUE(source) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) end
+        ) as session_source,
+
+        (case 
+          when FIRST_VALUE(medium) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) is null then "(none)"
+          else FIRST_VALUE(medium) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) end
+        ) as session_medium,
+
+        (case 
+          when FIRST_VALUE(campaign) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) is null then "(direct)"
+          else FIRST_VALUE(campaign) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) end
+        ) as session_campaign,
+
         FIRST_VALUE(default_channel_grouping) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS session_default_channel_grouping
     from set_default_channel_grouping
 )


### PR DESCRIPTION
## Description & motivation

Session source, medium and campaign are ofter used in combination for reporting. The campaign information was missing.

To increase the chance of finding values I excluded the events "session_start" and "first_visit" from the query, because they are usually the first events triggered but never contain this information. The results are now closer to the web UI of GA4.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)