### PR TITLE
session_engaged - using string instead of int value

### DIFF
--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -91,7 +91,7 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_location') }},
         {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value') }},
-        {{ ga4.unnest_key('event_params', 'session_engaged', 'int_value') }},
+        (case when (SELECT value.string_value FROM unnest(event_params) WHERE key = "session_engaged") = "1" then 1 end) as session_engaged,
         {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_title') }},
         {{ ga4.unnest_key('event_params', 'page_referrer') }},

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -57,7 +57,7 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_location') }},
         {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value') }},
-        {{ ga4.unnest_key('event_params', 'session_engaged', 'int_value') }},
+        (case when (SELECT value.string_value FROM unnest(event_params) WHERE key = "session_engaged") = "1" then 1 end) as session_engaged,
         {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_title') }},
         {{ ga4.unnest_key('event_params', 'page_referrer') }},


### PR DESCRIPTION
## Description & motivation

With the int value only like 50% of the conversions came engaged sessions. Also the average number of page views from unengaged sessions was above 1. That couldn't be right.

According to Google a sessions counts as engaged when it has more than 2 page views, a conversion or is longer than 10 seconds.

Using the string value seems to work better. I tested different options, but didn't find the perfect solution yet. A few sessions with more than 2 page view or conversions are still shown as unengaged. But it's only a few now.

In this article the string value is used:  https://stacktonic.com/article/enrich-a-single-customer-view-with-google-analytics-4-big-query-data

Here it's also the string value, but only from the "user_engagement" event:
https://www.ga4bigquery.com/tutorial-how-to-flatten-the-ga4-bigquery-export-schema-for-relational-databases-using-unnest/

If you have a better idea, please let me know.

## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable) - nothing to change
- [X] I have added tests & descriptions to my models (and macros if applicable) - nothing to change