### PR TITLE
Allow renaming of custom event parameters (#48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,11 +117,23 @@ For example:
 vars:
   ga4:
     page_view_custom_parameters:
-          - name: "clean_event"
-            value_type: "string_value"
-          - name: "country_code"
-            value_type: "int_value"
+      - name: "clean_event"
+        value_type: "string_value"
+      - name: "country_code"
+        value_type: "int_value"
 ```
+
+You can optionally rename the output column:
+
+```
+vars:
+  ga4:
+    page_view_custom_parameters:
+      - name: "country_code"
+        value_type: "int_value"
+        rename_to: "country"
+```
+
 ### User Properties
 
 User properties are provided by GA4 in the `user_properties` repeated field. The most recent user property for each user will be extracted and included in the `dim_ga4__users` model by configuring the `user_properties` variable in your project as follows:

--- a/macros/stage_custom_parameters.sql
+++ b/macros/stage_custom_parameters.sql
@@ -1,6 +1,6 @@
 {% macro stage_custom_parameters(custom_parameters ) %}
     {% for cp in custom_parameters %}
-        ,{{ ga4.unnest_key('event_params',  cp.name ,  cp.value_type ) }}
+        ,{{ ga4.unnest_key('event_params',  cp.name ,  cp.value_type, cp.rename_to or "default" ) }}
     {% endfor %}
 {% endmacro %}
 


### PR DESCRIPTION
## Description & motivation

If a custom parameter conflicts with one of the standard column names exported by the staging views, it's currently not possible to access it. `unnest_key` supports renaming so we should ideally support this in `stage_custom_parameters` too.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate exists tests