### PR TITLE
Support derived_session_properties (#54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Features include:
 | stg_ga4__event_to_query_string_params | Mapping between each event and any query parameters & values that were contained in the event's `page_location` field |
 | stg_ga4__user_properties | Finds the most recent occurance of specified user_properties for each user|
 | stg_ga4__derived_user_properties | Finds the most recent occurance of specific event_params and assigns them to a user's user_key. Derived user properties are specified as variables (see documentation below) |
+| stg_ga4__derived_session_properties | Finds the most recent occurance of specific event_params and assigns them to a session's session_key. Derived session properties are specified as variables (see documentation below) |
 | stg_ga4__session_conversions | Produces session-grouped event counts for a configurable list of event names (see documentation below) |
 | stg_ga4__sessions_traffic_sources | Finds the first source, medium, campaign and default channel grouping for each session |
 | dim_ga4__users | Dimension table for users which contains attributes such as first and last page viewed. Unique on `user_key` which is a hash of the `user_id` if it exists, otherwise it falls back to the `user_pseudo_id`.| 
@@ -174,6 +175,34 @@ vars:
           user_property_name: "most_recent_param"  
           value_type: "string_value"
 ```
+
+### Derived Session Properties
+
+Derived session properties are similar to derived user properties, but on a per-session basis, for properties that change slowly over time. This provides additional flexibility in allowing users to turn any event parameter into a session property. 
+
+Derived Session Properties are included in the `fct_ga4__sessions` model and contain the latest event parameter value per session. 
+
+```
+derived_session_properties:
+  - event_parameter: "[your event parameter]"
+    session_property_name: "[a unique name for the derived session property]"
+    value_type: "[string_value|int_value|float_value|double_value]"
+```
+
+For example: 
+
+```
+vars:
+  ga4:
+    derived_session_properties:
+      - event_parameter: "page_location"
+        session_property_name: "most_recent_page_location"
+        value_type: "string_value"
+      - event_parameter: "another_event_param"
+        session_property_name: "most_recent_param"
+        value_type: "string_value"
+```
+
 ### GA4 Recommended Events
 
 See the README file at /dbt_packages/models/staging/ga4/recommended_events for instructions on enabling [Google's recommended events](https://support.google.com/analytics/answer/9267735?hl=en).

--- a/integration_tests/test_stg_ga4__derived_session_properties.py
+++ b/integration_tests/test_stg_ga4__derived_session_properties.py
@@ -1,0 +1,74 @@
+import pytest
+from dbt.tests.util import read_file,check_relations_equal,run_dbt
+
+mock_stg_ga4__events_json = """
+{  "session_key": "AAA",  "event_timestamp": "1617691790431476",  "event_name": "first_visit",  "event_params": [{    "key": "my_param",    "value": {      "string_value": null,      "int_value": 1,      "float_value": null,      "double_value": null    }}]}
+{  "session_key": "AAA",  "event_timestamp": "1617691790431477",  "event_name": "first_visit",  "event_params": [{    "key": "my_param",    "value": {      "string_value": null,      "int_value": 2,      "float_value": null,      "double_value": null    }}]}
+{  "session_key": "BBB",  "event_timestamp": "1617691790431477",  "event_name": "first_visit",  "event_params": [{    "key": "my_param",    "value": {      "string_value": null,      "int_value": 1,      "float_value": null,      "double_value": null    }}]}
+""".lstrip()
+
+expected_csv = """session_key,my_derived_property
+AAA,2
+BBB,1
+""".lstrip()
+
+models__config_yml = """
+version: 2
+sources:
+  - name: fixture
+    schema: "{{ target.schema }}"
+    tables:
+      - name: mock_stg_ga4__events_json
+"""
+
+class TestDerivedSessionProperties():
+    # Update project name to ga4 so we can call macros with ga4.macro_name
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "ga4"
+        }
+
+    # everything that goes in the "seeds" directory (= CSV format)
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "expected.csv": expected_csv,
+        }
+
+    # everything that goes in the "models" directory (= SQL)
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "config.yml": models__config_yml,
+            "stg_ga4__events.sql": "select * from {{source('fixture','mock_stg_ga4__events_json')}}",
+            "actual.sql": read_file('../models/staging/ga4/stg_ga4__derived_session_properties.sql')
+        }
+
+    # everything that goes in the "macros"
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "unnest_key.sql": read_file('../macros/unnest_key.sql'),
+        }
+
+    def upload_json_fixture(self, project, file_name, json, table_name):
+        local_file_path = file_name
+        with open(local_file_path, "w") as outfile:
+            outfile.write(json)
+        project.adapter.upload_file(
+            local_file_path = local_file_path,
+            database = project.database,
+            table_schema = project.test_schema,
+            table_name = table_name,
+            kwargs = {
+                "source_format": "NEWLINE_DELIMITED_JSON",
+                "autodetect":"true"
+            }
+        )
+    
+    def test_mock_run_and_check(self, project):
+        self.upload_json_fixture(project, "source.json", mock_stg_ga4__events_json, "mock_stg_ga4__events_json" )
+        run_dbt(["build", "--vars", "derived_session_properties: [{'event_parameter':'my_param','session_property_name':'my_derived_property','value_type':'int_value'}]"])
+        #breakpoint()
+        check_relations_equal(project.adapter, ["actual", "expected"])

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -43,6 +43,12 @@ models:
       - name: user_key
         tests:
           - unique  
+  - name: stg_ga4__derived_session_properties
+    description: Optional model that will pull out the most recent instance of a particular event parameter for each session_key. Later used in the fct_ga4__sessions fact table.
+    columns:
+      - name: session_key
+        tests:
+          - unique  
   - name: stg_ga4__session_conversions
     description: Optional model that counts the number of events listed in the 'conversion_events' var. Aggregated by session_key.
   - name: stg_ga4__event_items

--- a/models/staging/ga4/stg_ga4__derived_session_properties.sql
+++ b/models/staging/ga4/stg_ga4__derived_session_properties.sql
@@ -1,0 +1,71 @@
+{{ config(
+  enabled = true if var('derived_session_properties', false) else false,
+  materialized = "table"
+) }}
+
+-- Remove null user_keys (users with privacy enabled)
+with events_from_valid_users as (
+    select * from {{ref('stg_ga4__events')}}
+    where session_key is not null
+),
+unnest_user_properties as
+(
+    select 
+        session_key,
+        event_timestamp
+        {% for sp in var('derived_session_properties', []) %}
+            ,{{ ga4.unnest_key('event_params',  sp.event_parameter ,  sp.value_type ) }}
+        {% endfor %}
+    from events_from_valid_users
+)
+-- create 1 CTE per user property that pulls only events with non-null values for that event parameters. 
+-- Find the most recent property for that user and join later
+{% for sp in var('derived_session_properties', []) %}
+,non_null_{{sp.event_parameter}} as
+(
+    select
+        session_key,
+        event_timestamp,
+        {{sp.event_parameter}}
+    from unnest_user_properties
+    where
+        {{sp.event_parameter}} is not null
+),
+last_value_{{sp.event_parameter}} as 
+(
+    select
+        session_key,
+        LAST_VALUE({{ sp.event_parameter }}) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {{sp.session_property_name}}
+    from non_null_{{sp.event_parameter}}
+),
+last_value_{{sp.event_parameter}}_grouped as 
+(
+    select
+        session_key,
+        {{sp.session_property_name}}
+    from last_value_{{sp.event_parameter}}
+    group by session_key, {{sp.session_property_name}}
+)
+{% endfor %}
+,
+user_keys as 
+(
+    select distinct
+        session_key
+    from events_from_valid_users
+),
+join_properties as 
+(
+    select
+        session_key
+        {% for sp in var('derived_session_properties', []) %}
+        ,last_value_{{sp.event_parameter}}_grouped.{{sp.session_property_name}}
+        {% endfor %}
+    from user_keys
+    {% for sp in var('derived_session_properties', []) %}
+    left join last_value_{{sp.event_parameter}}_grouped using (session_key)
+    {% endfor %}
+)
+
+
+select distinct * from join_properties


### PR DESCRIPTION
Fixes #54.

## Description & motivation

`derived_user_properties` is excellent and exactly what I needed for some of my properties that once set don't really change.

But we also have some event params that will most likely be different for each session, and putting them in `derived_user_properties` means we overwrite the old values for old sessions, which is not right for our data. For example, our shipping time estimates are per-session.

This PR implements a comparable `derived_session_properties`.

I debated whether these should go in the session dimension or fact table, but I see that the TODO says we should merge them anyway so I didn't stress about it, and to me this is more likely to be facts than dimensions.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests
