### PR TITLE
Base model partition optimization fixes

### DIFF
--- a/integration_tests/test_stg_ga4__events.py
+++ b/integration_tests/test_stg_ga4__events.py
@@ -2,20 +2,17 @@ import pytest
 from dbt.tests.util import read_file,check_relations_equal,run_dbt
 
 # Define mocks via CSV (seeds) or SQL (models)
-mock_base_ga4__events_csv = """user_id,user_pseudo_id,ga_session_id,stream_id,page_location,page_referrer
-user_id_1,user_pseudo_id_1,ga_session_id_1,stream_id_1,http://www.website.com/?foo=bar,http://www.cnn.com/
+mock_base_ga4__events_csv = """user_id,event_name,event_timestamp,user_pseudo_id,ga_session_id,stream_id,page_location,page_referrer
+user_id_1,pageview,12345,user_pseudo_id_1,ga_session_id_1,stream_id_1,http://www.website.com/?foo=bar,http://www.cnn.com/
 """.lstrip()
 
-#TODO
-#,user_pseudo_id_2,ga_session_id_1,stream_id_1,http://www.website.com
-
-expected_csv = """user_id,user_pseudo_id,ga_session_id,stream_id,user_key,session_key,session_event_number,event_key,original_page_location,original_page_referrer,page_location,page_referrer,page_hostname,page_query_string
-user_id_1,user_pseudo_id_1,ga_session_id_1,stream_id_1,c/nWU/GWhlWiLU0S6R/rwg==,9fDgaCrbd4ieAj1QpcWDjw==,1,FgBuqiZAGtlzSpZZgrY2VA==,http://www.website.com/?foo=bar,http://www.cnn.com/,http://www.website.com/?foo=bar,http://www.cnn.com/,website.com,foo=bar
+expected_csv = """user_id,event_name,event_timestamp,user_pseudo_id,ga_session_id,stream_id,user_key,session_key,event_key,original_page_location,original_page_referrer,page_location,page_referrer,page_hostname,page_query_string
+user_id_1,pageview,12345,user_pseudo_id_1,ga_session_id_1,stream_id_1,c/nWU/GWhlWiLU0S6R/rwg==,9fDgaCrbd4ieAj1QpcWDjw==,CuY6cWwqR4TDmeHhNHlnwQ==,http://www.website.com/?foo=bar,http://www.cnn.com/,http://www.website.com/?foo=bar,http://www.cnn.com/,website.com,foo=bar
 """
 
 actual = read_file('../models/staging/ga4/stg_ga4__events.sql')
 
-class TestUsersFirstLastEvents():
+class TestStgEvents():
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
     def seeds(self):

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -3,7 +3,6 @@
 with session_start_dims as (
     select 
         session_key,
-        ga_session_number,
         page_location as landing_page,
         page_hostname as landing_page_hostname,
         geo_continent,
@@ -31,23 +30,16 @@ with session_start_dims as (
         traffic_source_name,
         traffic_source_medium,
         traffic_source_source,
-        row_number() over (partition by session_key order by session_event_number asc) as row_num
     from {{ref('stg_ga4__event_session_start')}}
-),
--- Arbitrarily pull the first session_start event to remove duplicates
-remove_dupes as 
-(
-    select * from session_start_dims
-    where row_num = 1
 ),
 join_traffic_source as (
     select 
-        remove_dupes.*,
+        session_start_dims.*,
         session_source as source,
         session_medium as medium,
         session_campaign as campaign,
         session_default_channel_grouping as default_channel_grouping
-    from remove_dupes
+    from session_start_dims
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)
 )
 

--- a/models/marts/core/fct_ga4__pages.sql
+++ b/models/marts/core/fct_ga4__pages.sql
@@ -9,7 +9,6 @@ with page_view as (
         count(distinct user_key ) as users,
         sum( if(ga_session_number = 1,1,0)) as new_users,
         sum(entrances) as entrances,
-        sum(exits) as exits,
         sum(engagement_time_msec) as total_time_on_page 
 from {{ref('stg_ga4__event_page_view')}}
     group by 1,2,3,4,5

--- a/models/staging/ga4/events/stg_ga4__event_page_view.sql
+++ b/models/staging/ga4/events/stg_ga4__event_page_view.sql
@@ -2,7 +2,6 @@
    select *,
       {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
       {{ ga4.unnest_key('event_params', 'value', 'float_value') }},
-      lag(page_location, 1) over (partition by (session_key) order by event_timestamp asc) as session_previous_page,
       case when split(split(page_location,'/')[safe_ordinal(4)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(4)],'?')[safe_ordinal(1)]) end as pagepath_level_1,
       case when split(split(page_location,'/')[safe_ordinal(5)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(5)],'?')[safe_ordinal(1)]) end as pagepath_level_2,
       case when split(split(page_location,'/')[safe_ordinal(6)],'?')[safe_ordinal(1)] = '' then null else concat('/',split(split(page_location,'/')[safe_ordinal(6)],'?')[safe_ordinal(1)]) end as pagepath_level_3,
@@ -15,17 +14,6 @@
       {% endif %}
  from {{ref('stg_ga4__events')}}    
  where event_name = 'page_view'
-),
-last_pageview_joined as (
-  select 
-    page_view_with_params.*,
-    case
-      when first_last_pageview_session.last_page_view_event_key is null then null
-      else 1
-    end as exits
-  from page_view_with_params
-    left join {{ref('stg_ga4__sessions_first_last_pageviews')}} first_last_pageview_session
-      on page_view_with_params.event_key = first_last_pageview_session.last_page_view_event_key
 )
 
-select * from last_pageview_joined
+select * from page_view_with_params

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -31,10 +31,6 @@ models:
           - unique
   - name: stg_ga4__events
     description: Staging model that contains window functions used to generate unique keys
-    columns:
-      - name: event_key
-        tests:
-          - unique
   - name: stg_ga4__event_scroll
     description: Staging model containing only 'scroll' events. Includes the 'percent_scrolled' parameter.
   - name: stg_ga4__derived_user_properties

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -33,7 +33,7 @@ include_session_key as (
 include_event_key as (
     select 
         include_session_key.*,
-        to_base64(md5(CONCAT(CAST(session_key as STRING), CAST(1 as STRING)))) as event_key -- Surrogate key for unique events
+        to_base64(md5(CONCAT(CAST(session_key as STRING), CAST(event_timestamp as STRING)))) as event_key -- Surrogate key for unique events
     from include_session_key
 ),
 -- Remove specific query strings from page_location field

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -25,16 +25,16 @@ include_session_key as (
         to_base64(md5(CONCAT(stream_id, CAST(user_key as STRING), cast(ga_session_id as STRING)))) as session_key -- Surrogate key to determine unique session across streams and users. Sessions do NOT reset after midnight in GA4
     from add_user_key
 ),
-include_event_number as (
+/*include_event_number as (
     select include_session_key.*,
         row_number() over(partition by session_key) as session_event_number -- Number each event within a session to help generate a uniqu event key
     from include_session_key
-),
+),*/
 include_event_key as (
     select 
-        include_event_number.*,
-        to_base64(md5(CONCAT(CAST(session_key as STRING), CAST(session_event_number as STRING)))) as event_key -- Surrogate key for unique events
-    from include_event_number
+        include_session_key.*,
+        to_base64(md5(CONCAT(CAST(session_key as STRING), CAST(1 as STRING)))) as event_key -- Surrogate key for unique events
+    from include_session_key
 ),
 -- Remove specific query strings from page_location field
 remove_query_params as (

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -25,7 +25,9 @@ include_session_key as (
         to_base64(md5(CONCAT(stream_id, CAST(user_key as STRING), cast(ga_session_id as STRING)))) as session_key -- Surrogate key to determine unique session across streams and users. Sessions do NOT reset after midnight in GA4
     from add_user_key
 ),
-/*include_event_number as (
+/*
+-- Removing row_number() calculation as it negates the base table partition. Would like to include equivalent method of determining event uniqueness somehow
+include_event_number as (
     select include_session_key.*,
         row_number() over(partition by session_key) as session_event_number -- Number each event within a session to help generate a uniqu event key
     from include_session_key
@@ -33,7 +35,7 @@ include_session_key as (
 include_event_key as (
     select 
         include_session_key.*,
-        to_base64(md5(CONCAT(CAST(session_key as STRING), CAST(event_timestamp as STRING)))) as event_key -- Surrogate key for unique events
+        to_base64(md5(CONCAT(CAST(session_key as STRING), event_name, CAST(event_timestamp as STRING)))) as event_key -- Surrogate key for unique events
     from include_session_key
 ),
 -- Remove specific query strings from page_location field


### PR DESCRIPTION
## Description & motivation
Related to #40 , updated `stg_ga4__events` to remove the row number window function that was causing all base partitions to be scanned on every query. 

Also removed a window function from `stg_ga4__event_page_view` which had a similar effect on that model. 

Some discussion in #40 on how we should handle duplicate rows moving forward. The `event_key` field is now a surrogate key based on `session_key`, `event_name`, and `event_timestamp`, but that doesn't guarantee uniqueness. 

## Checklist
- [x ] I have verified that these changes work locally
- [x ] I have updated the README.md (if applicable)
- [x ] I have added tests & descriptions to my models (and macros if applicable)
- [x ] I have run `dbt test` and `python -m pytest .` to validate exists tests