### PR TITLE
Session event count metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ vars:
 Within GA4, you can add custom parameters to any event. These custom parameters will be picked up by this package if they are defined as variables within your `dbt_project.yml` file using the following syntax:
 
 ```
-[event name]_custom_parameters
+[event name]_custom_parameters:
   - name: "[name of custom parameter]"
     value_type: "[string_value|int_value|float_value|double_value]"
 ```
@@ -143,6 +143,14 @@ vars:
     default_custom_parameters:
       - name: "country_code"
         value_type: "int_value"
+```
+
+If you want to add the count of events other than the default page_views to your fct_ga4__sessions model, you can list which event names that you want to count using `session_event_count_metrics` and get a count of those events in each session, for example:
+
+```
+vars:
+  ga4:
+    session_event_count_metrics: ['add_to_cart','purchase']
 ```
 
 ### User Properties

--- a/macros/session_event_count_metrics.sql
+++ b/macros/session_event_count_metrics.sql
@@ -1,0 +1,5 @@
+{% macro session_event_count_metrics( event_name_array ) %}
+    {% for en in event_name_array %}
+        countif( event_name = '{{en}}' ) as count_{{en}},
+    {% endfor %}
+{% endmacro %}

--- a/models/marts/core/fct_ga4__sessions.sql
+++ b/models/marts/core/fct_ga4__sessions.sql
@@ -8,6 +8,9 @@ with session_metrics as
         min(event_date_dt) as session_start_date,
         min(event_timestamp) as session_start_timestamp,
         countif(event_name = 'page_view') as count_page_views,
+        {% if var("session_event_count_metrics") is defined and var("session_event_count_metrics")|length > 0  %}
+            {{ ga4.session_event_count_metrics( var("session_event_count_metrics") )}}
+        {% endif %}
         sum(event_value_in_usd) as sum_event_value_in_usd,
         ifnull(max(session_engaged), 0) as session_engaged,
         sum(engagement_time_msec) as sum_engagement_time_msec


### PR DESCRIPTION
## Description & motivation
This allows you to add event counts to the `fct_ga4__sessions` table in addition to the default count_page_views.

You configure it with an array custom parameter that matches event names and performs a `countif(event_name = 'array_item') as count_array_item`

## Checklist
- [ y] I have verified that these changes work locally
- [ y] I have updated the README.md (if applicable)
- [ n] I have added tests & descriptions to my models (and macros if applicable)
- [ n] I have run `dbt test` and `python -m pytest .` to validate exists tests