### PR TITLE
Add stream_id and platform to the sessions dimension table

### DIFF
--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -11,6 +11,8 @@ with session_start_dims as (
         geo_city,
         geo_sub_continent,
         geo_metro,
+        stream_id,
+        platform,
         device_category,
         device_mobile_brand_name,
         device_mobile_model_name,


### PR DESCRIPTION
## Description & motivation

We need this to distinguish between web & mobile app (ios/android) streams.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests