### PR TITLE
Add landing_page_referrer to the sessions dimensions table

### DIFF
--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -5,6 +5,7 @@ with session_start_dims as (
         session_key,
         page_location as landing_page,
         page_hostname as landing_page_hostname,
+        page_referrer as landing_page_referrer,
         geo_continent,
         geo_country,
         geo_region,


### PR DESCRIPTION
## Description & motivation

Although we have first_page_referrer on users, we didn't have anything at the session level, where we get the other landing page & campaign data.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate exists tests