### PR TITLE
Simplify derived user properties & session properties queries

### DIFF
--- a/models/staging/ga4/stg_ga4__derived_session_properties.sql
+++ b/models/staging/ga4/stg_ga4__derived_session_properties.sql
@@ -3,12 +3,12 @@
   materialized = "table"
 ) }}
 
--- Remove null user_keys (users with privacy enabled)
+-- Remove null session_keys (users with privacy enabled)
 with events_from_valid_users as (
     select * from {{ref('stg_ga4__events')}}
     where session_key is not null
 ),
-unnest_user_properties as
+unnest_event_params as
 (
     select 
         session_key,
@@ -18,54 +18,11 @@ unnest_user_properties as
         {% endfor %}
     from events_from_valid_users
 )
--- create 1 CTE per user property that pulls only events with non-null values for that event parameters. 
--- Find the most recent property for that user and join later
-{% for sp in var('derived_session_properties', []) %}
-,non_null_{{sp.event_parameter}} as
-(
-    select
-        session_key,
-        event_timestamp,
-        {{sp.event_parameter}}
-    from unnest_user_properties
-    where
-        {{sp.event_parameter}} is not null
-),
-last_value_{{sp.event_parameter}} as 
-(
-    select
-        session_key,
-        LAST_VALUE({{ sp.event_parameter }}) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {{sp.session_property_name}}
-    from non_null_{{sp.event_parameter}}
-),
-last_value_{{sp.event_parameter}}_grouped as 
-(
-    select
-        session_key,
-        {{sp.session_property_name}}
-    from last_value_{{sp.event_parameter}}
-    group by session_key, {{sp.session_property_name}}
-)
-{% endfor %}
-,
-user_keys as 
-(
-    select distinct
-        session_key
-    from events_from_valid_users
-),
-join_properties as 
-(
-    select
-        session_key
-        {% for sp in var('derived_session_properties', []) %}
-        ,last_value_{{sp.event_parameter}}_grouped.{{sp.session_property_name}}
-        {% endfor %}
-    from user_keys
+
+SELECT DISTINCT
+    session_key
     {% for sp in var('derived_session_properties', []) %}
-    left join last_value_{{sp.event_parameter}}_grouped using (session_key)
+        , LAST_VALUE({{ sp.event_parameter }} IGNORE NULLS) OVER (session_window) AS {{ sp.session_property_name }}
     {% endfor %}
-)
-
-
-select distinct * from join_properties
+FROM unnest_event_params
+WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)

--- a/models/staging/ga4/stg_ga4__derived_user_properties.sql
+++ b/models/staging/ga4/stg_ga4__derived_user_properties.sql
@@ -18,54 +18,11 @@ unnest_user_properties as
         {% endfor %}
     from events_from_valid_users
 )
--- create 1 CTE per user property that pulls only events with non-null values for that event parameters. 
--- Find the most recent property for that user and join later
-{% for up in var('derived_user_properties', []) %}
-,non_null_{{up.event_parameter}} as
-(
-    select
-        user_key,
-        event_timestamp,
-        {{up.event_parameter}}
-    from unnest_user_properties
-    where
-        {{up.event_parameter}} is not null
-),
-last_value_{{up.event_parameter}} as 
-(
-    select
-        user_key,
-        LAST_VALUE({{ up.event_parameter }}) OVER (PARTITION BY user_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS {{up.user_property_name}}
-    from non_null_{{up.event_parameter}}
-),
-last_value_{{up.event_parameter}}_grouped as 
-(
-    select
-        user_key,
-        {{up.user_property_name}}
-    from last_value_{{up.event_parameter}}
-    group by user_key, {{up.user_property_name}}
-)
-{% endfor %}
-,
-user_keys as 
-(
-    select distinct
-        user_key
-    from events_from_valid_users
-),
-join_properties as 
-(
-    select
-        user_key
-        {% for up in var('derived_user_properties', []) %}
-        ,last_value_{{up.event_parameter}}_grouped.{{up.user_property_name}}
-        {% endfor %}
-    from user_keys
+
+SELECT DISTINCT
+    user_key
     {% for up in var('derived_user_properties', []) %}
-    left join last_value_{{up.event_parameter}}_grouped using (user_key)
+        , LAST_VALUE({{ up.event_parameter }} IGNORE NULLS) OVER (user_window) AS {{ up.user_property_name }}
     {% endfor %}
-)
-
-
-select distinct * from join_properties
+FROM unnest_user_properties
+WINDOW user_window AS (PARTITION BY user_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)


### PR DESCRIPTION
## Description & motivation

Use LAST_VALUE with IGNORE NULLS and DISTINCT instead of a set of extra CTEs and joins.

To avoid 'Resources exceeded during query execution: Not enough resources for query planning - too many subqueries or query is too complex.' errors.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests