### PR TITLE
De-dup events in the base events queries (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,6 @@ vars:
     conversion_events:['purchase','download']
 ```
 
-# Event Key Uniqueness
-
-The `stg_ga4__events` model generates a surrogate key for each event using a combination of the session key, event name, event timestamp, and the event parameters. Given how GA4 (and specifically gtag.js) work, however, it is not uncommon to see multiple events containing exactly the same timestamps and parameters. This in turn creates duplicate `event_key` values and can introduce downstream issues when joining on `event_key`.  Running `dbt test -m stg_ga4__events` will fail if you have duplicate event keys. In these cases, the recommended approach is to update your collection implementation to include a new event parameter that will guarantee uniqueness for each event. For example, adding a `client_event_timestamp` or a `random_int` event parameter to each event should be sufficient to ensure that each `event_key` is unique.
-
 # Incremental Loading of Event Data (and how to handle late-arriving hits)
 
 By default, GA4 exports data into sharded event tables that use the event date as the table suffix in the format of `events_YYYYMMDD` or `events_intraday_YYYYMMDD`. This package incrementally loads data from these tables into `base_ga4__events` which is partitioned on date. There are two incremental loading strategies available:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Features include:
 
 | model | description |
 |-------|-------------|
-| stg_ga4__events | Contains cleaned event data that is enhanced with useful event and session keys. See note below regarding cases where event keys may not be unique.|
+| stg_ga4__events | Contains cleaned event data that is enhanced with useful event and session keys. |
 | stg_ga4__event_* | 1 model per event (ex: page_view, purchase) which flattens event parameters specific to that event |
 | stg_ga4__event_items | Contains item data associated with e-commerce events (Purchase, add to cart, etc) |
 | stg_ga4__event_to_query_string_params | Mapping between each event and any query parameters & values that were contained in the event's `page_location` field |

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -141,10 +141,9 @@ renamed as (
         CASE 
             WHEN event_name = 'purchase' THEN 1
             ELSE 0
-        END AS is_purchase,
+        END AS is_purchase
     from source
 )
 
-select
-    *
-from renamed
+select * from renamed
+qualify row_number() over(partition by event_date_dt, stream_id, user_pseudo_id, ga_session_id, event_name, event_timestamp, to_json_string(event_params)) = 1

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -111,3 +111,4 @@ renamed as (
 )
 
 select * from renamed
+qualify row_number() over(partition by event_date_dt, stream_id, user_pseudo_id, ga_session_id, event_name, event_timestamp, to_json_string(event_params)) = 1

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -29,7 +29,7 @@ include_session_key as (
 include_event_key as (
     select 
         include_session_key.*,
-        to_base64(md5(CONCAT(session_key, event_name, CAST(event_timestamp as STRING), to_json_string(event_params)))) as event_key -- Surrogate key for unique events. These keys may not be unique given how GA4 operates. 
+        to_base64(md5(CONCAT(session_key, event_name, CAST(event_timestamp as STRING), to_json_string(event_params)))) as event_key -- Surrogate key for unique events.  
     from include_session_key
 ),
 detect_gclid as (


### PR DESCRIPTION
## Description & motivation

Fix duplicate event errors as discussed with @adamribaudo-velir and @dgitis in #74.

Previously we did this in the stg_ga4__events view, but that turned out to be incompatible with parition pruning, an important cost optimization.

Doing it in the "base" queries does not suffer from this problem because the incremental update process ensures that we are only querying one date partition at a time anyway, which is the right granularity to run de-duping at because the duplicate events have duplicate event_date_dt/event_timestamp values and therefore get delivered into the same partition.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests

Benchmarks below.