### PR TITLE
Utm content and term

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Features include:
 | stg_ga4__derived_user_properties | Finds the most recent occurance of specific event_params and assigns them to a user's user_key. Derived user properties are specified as variables (see documentation below) |
 | stg_ga4__derived_session_properties | Finds the most recent occurance of specific event_params and assigns them to a session's session_key. Derived session properties are specified as variables (see documentation below) |
 | stg_ga4__session_conversions | Produces session-grouped event counts for a configurable list of event names (see documentation below) |
-| stg_ga4__sessions_traffic_sources | Finds the first source, medium, campaign and default channel grouping for each session |
+| stg_ga4__sessions_traffic_sources | Finds the first source, medium, campaign, content, paid search term (from UTM tracking), and default channel grouping for each session |
 | dim_ga4__users | Dimension table for users which contains attributes such as first and last page viewed. Unique on `user_key` which is a hash of the `user_id` if it exists, otherwise it falls back to the `user_pseudo_id`.| 
 | dim_ga4__sessions | Dimension table for sessions which contains useful attributes such as geography, device information, and campaign data |
 | fct_ga4__pages | Fact table for pages which aggregates common page metrics by page_location, date, and hour. |

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -41,6 +41,8 @@ join_traffic_source as (
         session_source as source,
         session_medium as medium,
         session_campaign as campaign,
+        session_content as content,
+        session_term as term,
         session_default_channel_grouping as default_channel_grouping
     from session_start_dims
     left join {{ref('stg_ga4__sessions_traffic_sources')}} using (session_key)

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -134,6 +134,8 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'source') }},
         {{ ga4.unnest_key('event_params', 'medium') }},
         {{ ga4.unnest_key('event_params', 'campaign') }},
+        {{ ga4.unnest_key('event_params', 'content') }},
+        {{ ga4.unnest_key('event_params', 'term') }},
         CASE 
             WHEN event_name = 'page_view' THEN 1
             ELSE 0

--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -99,6 +99,8 @@ renamed as (
         {{ ga4.unnest_key('event_params', 'source') }},
         {{ ga4.unnest_key('event_params', 'medium') }},
         {{ ga4.unnest_key('event_params', 'campaign') }},
+        {{ ga4.unnest_key('event_params', 'content') }},
+        {{ ga4.unnest_key('event_params', 'term') }},
         CASE 
             WHEN event_name = 'page_view' THEN 1
             ELSE 0

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -77,3 +77,11 @@ models:
         description: campaign value of the first event of the session after session_start and first_visit
         tests:
           - not_null
+      - name: session_content
+        description: content value of the first event of the session after session_start and first_visit
+        tests:
+          - not_null
+      - name: session_term
+        description: term value of the first event of the session after session_start and first_visit
+        tests:
+          - not_null

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -25,7 +25,7 @@ session_source as (
         session_key,
         COALESCE(FIRST_VALUE(source) OVER (session_window), "(direct)") AS session_source,
         COALESCE(FIRST_VALUE(medium) OVER (session_window), "(none)") AS session_medium,
-        COALESCE(FIRST_VALUE(campaign) OVER (session_window), "(direct)") AS session_campaign,
+        COALESCE(FIRST_VALUE(campaign) OVER (session_window), "(none)") AS session_campaign,
         COALESCE(FIRST_VALUE(content) OVER (session_window), "(none)") AS session_content,
         COALESCE(FIRST_VALUE(term) OVER (session_window), "(none)") AS session_term,
         FIRST_VALUE(default_channel_grouping) OVER (session_window) AS session_default_channel_grouping

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -5,6 +5,8 @@ with session_events as (
         lower(source) as source,
         medium,
         campaign,
+        content,
+        term,
         source_category
     from {{ref('stg_ga4__events')}}
     left join {{ref('ga4_source_categories')}} using (source)
@@ -24,6 +26,8 @@ session_source as (
         COALESCE(FIRST_VALUE(source) OVER (session_window), "(direct)") AS session_source,
         COALESCE(FIRST_VALUE(medium) OVER (session_window), "(none)") AS session_medium,
         COALESCE(FIRST_VALUE(campaign) OVER (session_window), "(direct)") AS session_campaign,
+        COALESCE(FIRST_VALUE(content) OVER (session_window), "(none)") AS session_content,
+        COALESCE(FIRST_VALUE(term) OVER (session_window), "(none)") AS session_term,
         FIRST_VALUE(default_channel_grouping) OVER (session_window) AS session_default_channel_grouping
     from set_default_channel_grouping
     WINDOW session_window AS (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)


### PR DESCRIPTION
## Description & motivation

Extract content & term UTM parameters too
    
Until now we've extracted 3 of the standard UTM tracking parameters (documented at https://en.wikipedia.org/wiki/UTM_parameters#UTM_parameters). This completes the set.

Our marketing agencies use these fields to track campaign creatives and paid keyword performance.

NB. I don't love how generic-sounding these column names are, but I've followed the pattern we've used so far. Perhaps we should be renaming them all back to `utm_*` to be clearer, but that isn't how they come through in event_params.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests