### PR TITLE
Support deriving session properties from user_properties too

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Features include:
 | stg_ga4__event_* | 1 model per event (ex: page_view, purchase) which flattens event parameters specific to that event |
 | stg_ga4__event_items | Contains item data associated with e-commerce events (Purchase, add to cart, etc) |
 | stg_ga4__event_to_query_string_params | Mapping between each event and any query parameters & values that were contained in the event's `page_location` field |
-| stg_ga4__user_properties | Finds the most recent occurance of specified user_properties for each user|
-| stg_ga4__derived_user_properties | Finds the most recent occurance of specific event_params and assigns them to a user's user_key. Derived user properties are specified as variables (see documentation below) |
-| stg_ga4__derived_session_properties | Finds the most recent occurance of specific event_params and assigns them to a session's session_key. Derived session properties are specified as variables (see documentation below) |
+| stg_ga4__user_properties | Finds the most recent occurance of specified user_properties for each user |
+| stg_ga4__derived_user_properties | Finds the most recent occurance of specific event_params value and assigns them to a user's user_key. Derived user properties are specified as variables (see documentation below) |
+| stg_ga4__derived_session_properties | Finds the most recent occurance of specific event_params or user_properties value and assigns them to a session's session_key. Derived session properties are specified as variables (see documentation below) |
 | stg_ga4__session_conversions | Produces session-grouped event counts for a configurable list of event names (see documentation below) |
 | stg_ga4__sessions_traffic_sources | Finds the first source, medium, campaign and default channel grouping for each session |
 | dim_ga4__users | Dimension table for users which contains attributes such as first and last page viewed. Unique on `user_key` which is a hash of the `user_id` if it exists, otherwise it falls back to the `user_pseudo_id`.| 
@@ -190,11 +190,14 @@ vars:
 
 Derived session properties are similar to derived user properties, but on a per-session basis, for properties that change slowly over time. This provides additional flexibility in allowing users to turn any event parameter into a session property. 
 
-Derived Session Properties are included in the `fct_ga4__sessions` model and contain the latest event parameter value per session. 
+Derived Session Properties are included in the `fct_ga4__sessions` model and contain the latest event parameter or user property value per session.
 
 ```
 derived_session_properties:
   - event_parameter: "[your event parameter]"
+    session_property_name: "[a unique name for the derived session property]"
+    value_type: "[string_value|int_value|float_value|double_value]"
+  - user_property: "[your user property key]"
     session_property_name: "[a unique name for the derived session property]"
     value_type: "[string_value|int_value|float_value|double_value]"
 ```
@@ -211,6 +214,9 @@ vars:
       - event_parameter: "another_event_param"
         session_property_name: "most_recent_param"
         value_type: "string_value"
+      - user_property: "first_open_time"
+        session_property_name: "first_open_time"
+        value_type: "int_value"
 ```
 
 ### GA4 Recommended Events

--- a/integration_tests/test_stg_ga4__derived_session_properties.py
+++ b/integration_tests/test_stg_ga4__derived_session_properties.py
@@ -2,14 +2,14 @@ import pytest
 from dbt.tests.util import read_file,check_relations_equal,run_dbt
 
 mock_stg_ga4__events_json = """
-{  "session_key": "AAA",  "event_timestamp": "1617691790431476",  "event_name": "first_visit",  "event_params": [{    "key": "my_param",    "value": {      "string_value": null,      "int_value": 1,      "float_value": null,      "double_value": null    }}]}
+{  "session_key": "AAA",  "event_timestamp": "1617691790431476",  "event_name": "first_visit",  "event_params": [{    "key": "my_param",    "value": {      "string_value": null,      "int_value": 1,      "float_value": null,      "double_value": null    }}],  "user_properties": [{    "key": "my_property",    "value": {      "string_value": "value1",      "int_value": null,      "float_value": null,      "double_value": null    }}]}
 {  "session_key": "AAA",  "event_timestamp": "1617691790431477",  "event_name": "first_visit",  "event_params": [{    "key": "my_param",    "value": {      "string_value": null,      "int_value": 2,      "float_value": null,      "double_value": null    }}]}
-{  "session_key": "BBB",  "event_timestamp": "1617691790431477",  "event_name": "first_visit",  "event_params": [{    "key": "my_param",    "value": {      "string_value": null,      "int_value": 1,      "float_value": null,      "double_value": null    }}]}
+{  "session_key": "BBB",  "event_timestamp": "1617691790431477",  "event_name": "first_visit",  "event_params": [{    "key": "my_param",    "value": {      "string_value": null,      "int_value": 1,      "float_value": null,      "double_value": null    }}],  "user_properties": [{    "key": "my_property",    "value": {      "string_value": "value2",      "int_value": null,      "float_value": null,      "double_value": null    }}]}
 """.lstrip()
 
-expected_csv = """session_key,my_derived_property
-AAA,2
-BBB,1
+expected_csv = """session_key,my_derived_property,my_derived_property2
+AAA,2,value1
+BBB,1,value2
 """.lstrip()
 
 models__config_yml = """
@@ -69,6 +69,6 @@ class TestDerivedSessionProperties():
     
     def test_mock_run_and_check(self, project):
         self.upload_json_fixture(project, "source.json", mock_stg_ga4__events_json, "mock_stg_ga4__events_json" )
-        run_dbt(["build", "--vars", "derived_session_properties: [{'event_parameter':'my_param','session_property_name':'my_derived_property','value_type':'int_value'}]"])
+        run_dbt(["build", "--vars", "derived_session_properties: [{'event_parameter':'my_param','session_property_name':'my_derived_property','value_type':'int_value'},{'user_property':'my_property','session_property_name':'my_derived_property2','value_type':'string_value'}]"])
         #breakpoint()
         check_relations_equal(project.adapter, ["actual", "expected"])


### PR DESCRIPTION
## Description & motivation

We have user_properties and derived_user_properties, and later I introduced derived_session_properties. But, there was no way to get a user_property value at a session level.

What I've found is that some user properties do slowly change over time, and so taking the very latest value from user_properties for the user means join queries show incorrect historic data changes.

This gives us the option to limit user_property data collection to session length. It happens to be a more natural data model for one of my user properties to think of it as a session level thing anyway; we use user properties rather than event params for that one because we want the GA4 behavior of applying user properties back to the start of the session for its built-in reporting.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests