### PR TITLE
use utm parameters also if gclid is found

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'ga4'
-version: '0.1.4'
+version: '2.0.1'
 config-version: 2
 model-paths: ["models"]
 analysis-paths: ["analyses"]

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -41,13 +41,17 @@ include_event_key as (
 ),
 detect_gclid as (
     select
-        * except (medium, campaign),
+        * except (source, medium, campaign),
         case
-            when page_location like '%gclid%' then "cpc"
+            when (page_location like '%gclid%' and source is null) then "google"
+            else source
+        end as source,
+        case
+            when (page_location like '%gclid%' and medium is null) then "cpc"
             else medium
         end as medium,
         case
-            when page_location like '%gclid%' then "(cpc)"
+            when (page_location like '%gclid%' and campaign is null) then "(cpc)"
             else campaign
         end as campaign
     from include_event_key

--- a/unit_tests/README.md
+++ b/unit_tests/README.md
@@ -5,7 +5,7 @@ The dbt-ga4 package treats each model and macro as a 'unit' of code. If we fix t
 - https://docs.getdbt.com/docs/contributing/testing-a-new-adapter
 - https://github.com/dbt-labs/dbt-core/discussions/4455#discussioncomment-2766503
 
-You'll need to install pytest, pytest-dotenv and create a `.env` file with a `BQ_PROJECT` key containing the name of your BigQuery project. An 'oauth' connection method is assumed for local development. 
+You'll need to install pytest, pytest-dotenv and create a `.env` file with a `BIGQUERY_PROJECT` key containing the name of your BigQuery project. An 'oauth' connection method is assumed for local development. 
 
 Installing pytest & pytest-dotenv can be done using the requirements.txt file. Navigate to the `integration_tests` folder and run 
 


### PR DESCRIPTION
## Description & motivation

When I was testing version 2.0.0, I discovered that the utm parameters for visitors from Google Ads are not taken into account anymore. The source information for all traffic with a gclid parameter in the URL was overwritten with medium "cpc" and campaign "(cpc)".

I changed the condition to only set the default value if no utm information is available (if source / medium / campaign are null). Now it's more like a fallback solution and I can see the utm information again in the dashboards and display traffic from Google Ads is also categorized correctly.


## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests