### PR TITLE
Fix automated unit tests - updated config to look for service json relative to workspace

### DIFF
--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -3,7 +3,6 @@ name: Run Unit Tests on Pull Request
 on: [pull_request,workflow_dispatch]
 env:
   BIGQUERY_PROJECT: ${{ secrets.BIGQUERY_PROJECT }}
-  KEYFILE_LOCATION: /dbt-service-account.json
 
 jobs:
   pytest_run_all:

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -12,7 +12,7 @@ def dbt_profile_target():
         return {
             'type': 'bigquery',
             'method': 'service-account',
-            'keyfile': os.getcwd() + os.environ.get("KEYFILE_LOCATION"),
+            'keyfile': os.environ.get("GITHUB_WORKSPACE") + "/unit_tests/dbt-service-account.json",
             'threads': 4,
             'timeout_seconds': 300,
             'project':  os.environ.get("BIGQUERY_PROJECT")


### PR DESCRIPTION
## Description & motivation
I noticed that in some cases, the unit tests were looking for the service account JSON relative to the unit test project directory, not the github workspace. Turns out that the github workspace is available as an environmental variable [${GITHUB_WORKSPACE}](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables)

## Checklist
- [na ] I have verified that these changes work locally
- [na ] I have updated the README.md (if applicable)
- [na ] I have added tests & descriptions to my models (and macros if applicable)
- [x ] I have run `dbt test` and `python -m pytest .` to validate exists tests