### PR TITLE
Refactor page conversion count and unit test

### DIFF
--- a/models/marts/core/fct_ga4__pages.sql
+++ b/models/marts/core/fct_ga4__pages.sql
@@ -16,13 +16,14 @@ with page_view as (
         event_date_dt,
         extract( hour from (select  timestamp_micros(event_timestamp))) as hour,
         page_location,  -- includes query string parameters not listed in query_parameter_exclusions variable
-        concat( cast(event_date_dt as string), cast(extract( hour from (select  timestamp_micros(event_timestamp))) as string), page_location ) as page_key,
+        page_key,
         page_title,  -- would like to move this to dim_ga4__pages but need to think how to handle page_title changing over time
         count(event_name) as page_views,
         count(distinct user_key ) as users,
         sum( if(ga_session_number = 1,1,0)) as new_users,
         sum(entrances) as entrances,
         sum(engagement_time_msec) as total_time_on_page 
+        
 from {{ref('stg_ga4__event_page_view')}}
     group by 1,2,3,4,5
 ), scroll as (

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -79,5 +79,11 @@ enrich_params as (
         {{extract_hostname_from_url('page_location')}} as page_hostname,
         {{extract_query_string_from_url('page_location')}} as page_query_string,
     from remove_query_params
+),
+page_key as (
+    select
+        *,
+        (concat( cast(event_date_dt as string), cast(EXTRACT(HOUR FROM TIMESTAMP_MICROS(event_timestamp)) as string), page_location )) as page_key
+    from enrich_params
 )
-select * from enrich_params
+select * from page_key

--- a/models/staging/ga4/stg_ga4__page_conversions.sql
+++ b/models/staging/ga4/stg_ga4__page_conversions.sql
@@ -1,47 +1,11 @@
 {{ config(
   enabled= var('conversion_events', false) != false
 ) }}
-with events as (
-    select 
-        1 as event_count,
-        event_name,
-        event_date_dt,
-        extract( hour from (select  timestamp_micros(event_timestamp))) as hour,
-        page_location
-    from {{ref('stg_ga4__events')}}
-),
-pk as (
-    select
-        distinct (concat( cast(event_date_dt as string), cast(hour as string), page_location )) as page_key,
-    from events
-)
--- For loop that creates 1 cte per conversions, grouped by page_location
-{% for ce in var('conversion_events',[]) %}
-,
-conversion_{{ce}} as (
-    select
-        distinct (concat( cast(event_date_dt as string), cast(hour as string), page_location )) as page_key,
-        sum(event_count) as conversion_count,
-    from events
-    where event_name = '{{ce}}'
-    group by page_key
-)
 
-{% endfor %}
-
-,
--- Finally, join in each conversion count as a new column
-final_pivot as (
-    select 
-        page_key
-        {% for ce in var('conversion_events',[]) %}
-        , ifnull(conversion_{{ce}}.conversion_count,0) as {{ce}}_count
-        {% endfor %}
-    from pk
+select 
+    page_key
     {% for ce in var('conversion_events',[]) %}
-    left join conversion_{{ce}} using (page_key)
+    , countif(event_name = '{{ce}}') as {{ce}}_count
     {% endfor %}
-)
-
-select * from final_pivot
-
+from {{ref('stg_ga4__events')}}
+group by 1

--- a/unit_tests/test_stg_ga4__page_conversions.py
+++ b/unit_tests/test_stg_ga4__page_conversions.py
@@ -33,5 +33,5 @@ class TestPageConversions():
     
     def test_mock_run_and_check(self, project):
         run_dbt(["build", "--vars", "conversion_events: ['page_view']"])
-        breakpoint()
+        #breakpoint()
         check_relations_equal(project.adapter, ["actual", "expected"])

--- a/unit_tests/test_stg_ga4__page_conversions.py
+++ b/unit_tests/test_stg_ga4__page_conversions.py
@@ -2,15 +2,15 @@ import pytest
 from dbt.tests.util import read_file,check_relations_equal,run_dbt
 
 # Define mocks via CSV (seeds) or SQL (models)
-mock_stg_ga4__events_csv = """event_name,event_date_dt,event_timestamp,page_location
-page_view,20220623,1655992867599369,www.cnn.com
-page_view,20220623,1655992982011685,www.cnn.com
-page_view,20220623,1655992867599369,www.google.com
+mock_stg_ga4__events_csv = """event_name,page_key
+page_view,A
+page_view,A
+page_view,B
 """.lstrip()
 
 expected_csv = """page_key,page_view_count
-2022062314www.cnn.com,2
-2022062314www.google.com,1
+A,2
+B,1
 """.lstrip()
 
 actual = read_file('../models/staging/ga4/stg_ga4__page_conversions.sql')
@@ -33,5 +33,5 @@ class TestPageConversions():
     
     def test_mock_run_and_check(self, project):
         run_dbt(["build", "--vars", "conversion_events: ['page_view']"])
-        #breakpoint()
+        breakpoint()
         check_relations_equal(project.adapter, ["actual", "expected"])


### PR DESCRIPTION
## Description & motivation
Responding to #97 

Refactored how page conversions are counted. Create `page_key` in the `stg_ga4__events` model rather than multiple times downstream. Should help with performance.

## Checklist
- [x ] I have verified that these changes work locally
- [na ] I have updated the README.md (if applicable)
- [x ] I have added tests & descriptions to my models (and macros if applicable)
- [x ] I have run `dbt test` and `python -m pytest .` to validate exists tests