### PR TITLE
Allow users to override default_channel_grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ This package uses `pytest` as a method of unit testing individual models. More d
 
 By default, this package maps traffic sources to channel groupings using the `macros/default_channel_grouping.sql` macro. This macro closely adheres to Googls recommended channel groupings documented here: https://support.google.com/analytics/answer/9756891?hl=en .
 
-Package users can override this macro and implement their own channel groupins by following these steps:
+Package users can override this macro and implement their own channel groupings by following these steps:
 - Create a macro in your project named `default__default_channel_grouping` that accepts the same 3 arguments: source, medium, source_category
 - Implement your custom logic within that macro. It may be easiest to first copy the code from the package macro and modify from there.
 

--- a/README.md
+++ b/README.md
@@ -266,3 +266,13 @@ gcloud auth application-default login --scopes=https://www.googleapis.com/auth/b
 # Unit Testing
 
 This package uses `pytest` as a method of unit testing individual models. More details can be found in the [unit_tests/README.md](unit_tests) folder.
+
+# Overriding Default Channel Groupings
+
+By default, this package maps traffic sources to channel groupings using the `macros/default_channel_grouping.sql` macro. This macro closely adheres to Googls recommended channel groupings documented here: https://support.google.com/analytics/answer/9756891?hl=en .
+
+Package users can override this macro and implement their own channel groupins by following these steps:
+- Create a macro in your project named `default__default_channel_grouping` that accepts the same 3 arguments: source, medium, source_category
+- Implement your custom logic within that macro. It may be easiest to first copy the code from the package macro and modify from there.
+
+Overriding the package's default channel mapping makes use of dbt's dispatch override capability documented here: https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch#overriding-package-macros

--- a/macros/default_channel_grouping.sql
+++ b/macros/default_channel_grouping.sql
@@ -3,7 +3,10 @@
 -- source_category Excel file can be downloaded from the above link and may change over time
 
 {% macro default_channel_grouping(source, medium, source_category) %}
+  {{ return(adapter.dispatch('default_channel_grouping', 'ga4')(source, medium, source_category)) }}
+{%- endmacro %}
 
+{% macro default__default_channel_grouping(source, medium, source_category) %}
 case 
   when {{source}} is null and {{medium}} is null 
     then 'Direct'

--- a/macros/default_channel_grouping.sql
+++ b/macros/default_channel_grouping.sql
@@ -4,7 +4,7 @@
 
 {% macro default_channel_grouping(source, medium, source_category) %}
   {{ return(adapter.dispatch('default_channel_grouping', 'ga4')(source, medium, source_category)) }}
-{%- endmacro %}
+{% endmacro %}
 
 {% macro default__default_channel_grouping(source, medium, source_category) %}
 case 

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -15,7 +15,7 @@ with session_events as (
 set_default_channel_grouping as (
     select
         *,
-        {{ga4.default_channel_grouping('source','medium','source_category')}} as default_channel_grouping
+        {{default_channel_grouping('source','medium','source_category')}} as default_channel_grouping
     from session_events
 ),
 session_source as (

--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -15,7 +15,7 @@ with session_events as (
 set_default_channel_grouping as (
     select
         *,
-        {{default_channel_grouping('source','medium','source_category')}} as default_channel_grouping
+        {{ga4.default_channel_grouping('source','medium','source_category')}} as default_channel_grouping
     from session_events
 ),
 session_source as (

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -23,3 +23,7 @@ def dbt_profile_target():
         'threads': 4,
         'project':  os.environ.get("BIGQUERY_PROJECT")
     }
+
+@pytest.fixture(scope="class")
+def project_config_update():
+    return {'name': 'ga4'}

--- a/unit_tests/test_macro_default_channel_grouping.py
+++ b/unit_tests/test_macro_default_channel_grouping.py
@@ -67,5 +67,6 @@ class TestUsersFirstLastEvents():
         }
     
     def test_mock_run_and_check(self, project):
+        #breakpoint()
         run_dbt(["build"])
         check_relations_equal(project.adapter, ["actual", "expected"])


### PR DESCRIPTION
## Description & motivation
Implementation of `adapter.dispatch` within the `default_channel_grouping` macro to allow end-users to override this macro and use their own channel mapping. Instructions were added to the README:

```
By default, this package maps traffic sources to channel groupings using the macros/default_channel_grouping.sql macro. This macro closely adheres to Googls recommended channel groupings documented here: https://support.google.com/analytics/answer/9756891?hl=en .

Package users can override this macro and implement their own channel groupins by following these steps:

Create a macro in your project named default__default_channel_grouping that accepts the same 3 arguments: source, medium, source_category
Implement your custom logic within that macro. It may be easiest to first copy the code from the package macro and modify from there.
Overriding the package's default channel mapping makes use of dbt's dispatch override capability documented here: https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch#overriding-package-macros
```

## Checklist
- [ x] I have verified that these changes work locally
- [ x] I have updated the README.md (if applicable)
- [ na] I have added tests & descriptions to my models (and macros if applicable)
- [ x] I have run `dbt test` and `python -m pytest .` to validate exists tests