### PR TITLE
correct data_type of tax and value

### DIFF
--- a/models/staging/ga4/recommended_events/stg_ga4__event_purchase.sql
+++ b/models/staging/ga4/recommended_events/stg_ga4__event_purchase.sql
@@ -16,8 +16,8 @@ with purchase_with_params as (
     {{ ga4.unnest_key('event_params', 'coupon') }},
     {{ ga4.unnest_key('event_params', 'transaction_id') }},
     {{ ga4.unnest_key('event_params', 'currency') }},
-    {{ ga4.unnest_key('event_params', 'value', 'float_value') }},
-    {{ ga4.unnest_key('event_params', 'tax', 'float_value') }},
+    {{ ga4.unnest_key('event_params', 'value', 'double_value') }},
+    {{ ga4.unnest_key('event_params', 'tax', 'double_value') }},
     {{ ga4.unnest_key('event_params', 'shipping', 'float_value') }},
     {{ ga4.unnest_key('event_params', 'affiliation') }}
     {% if var("default_custom_parameters", "none") != "none" %}


### PR DESCRIPTION
## Description & motivation
<!---
The type data of tax a nd value is not float_value but  double_value
For details see. Issue #114
-->

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests