### PR TITLE
Added event_name clustering to base event model

### DIFF
--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -12,6 +12,7 @@
                 "data_type": "date",
             },
             partitions = partitions_to_replace,
+            cluster_by=['event_name']
         )
     }}
 {% else %}
@@ -23,6 +24,7 @@
                 "field": "event_date_dt",
                 "data_type": "date",
             },
+            cluster_by=['event_name']
         )
     }}
 {% endif %}


### PR DESCRIPTION
## Description & motivation
 
As noted in #117, we can speed up the filtering by event name by using BQ clustering (documented here: https://cloud.google.com/bigquery/docs/clustered-tables ). Performance gains are seen when tables are larger than 1GB.

## Checklist
- [x ] I have verified that these changes work locally
- [ na] I have updated the README.md (if applicable)
- [ na] I have added tests & descriptions to my models (and macros if applicable)
- [x ] I have run `dbt test` and `python -m pytest .` to validate exists tests