### PR TITLE
Use copy_partition strategy for base event incremental model to save on processing time and cost

### DIFF
--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -9,8 +9,7 @@
             incremental_strategy = 'insert_overwrite',
             partition_by={
                 "field": "event_date_dt",
-                "data_type": "date",
-                "copy_partitions": true
+                "data_type": "date"
             },
             partitions = partitions_to_replace,
             

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -10,8 +10,10 @@
             partition_by={
                 "field": "event_date_dt",
                 "data_type": "date",
+                "copy_partitions": true
             },
             partitions = partitions_to_replace,
+            
         )
     }}
 {% else %}
@@ -22,7 +24,9 @@
             partition_by={
                 "field": "event_date_dt",
                 "data_type": "date",
+                "copy_partitions": true
             },
+            
         )
     }}
 {% endif %}


### PR DESCRIPTION
## Description & motivation

As mentioned in #115, dbt 1.4.0 released the ability to use BQ's 'copy' command as opposed to a 'merge' command to update incremental models. This can save on both processing time and cost. In my own testing of merging in 1.4M rows, I saw the following results:

Status quo:
```
3.27 GB billed

03:19:22  1 of 1 START sql incremental model dbt_dev_aribaudo.base_ga4__events ........... [RUN]
03:20:03  1 of 1 OK created sql incremental model dbt_dev_aribaudo.base_ga4__events ...... [SCRIPT (3.3 GB processed) in 41.09s]
03:20:03
03:20:03  Finished running 1 incremental model in 0 hours 0 minutes and 41.98 seconds (41.98s).
```
With copy_partition:

```
03:17:02  1 of 1 START sql incremental model dbt_dev_aribaudo.base_ga4__events ........... [RUN]
03:17:40  1 of 1 OK created sql incremental model dbt_dev_aribaudo.base_ga4__events ...... [None (0 processed) in 38.13s]
03:17:40
03:17:40  Finished running 1 incremental model in 0 hours 0 minutes and 39.06 seconds (39.06s).
```

So not only did I shave 2 seconds off the processing time, but I was billed for 0 bytes instead of 3.8GB. Seems like a no brainer, given the ease of configuration and its availability in dbt-bigquery.


## Checklist
- [x ] I have verified that these changes work locally
- [na ] I have updated the README.md (if applicable)
- [na ] I have added tests & descriptions to my models (and macros if applicable)
- [x ] I have run `dbt test` and `python -m pytest .` to validate exists tests