### PR TITLE
Modified section "Custom Parameters"

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ vars:
 ```
 ### Custom Parameters
 
-Within GA4, you can add custom parameters to any event. These custom parameters will be picked up by this package if they are defined as variables within your `dbt_project.yml` file using the following syntax:
+Within GA4, you can add custom parameters to any event. These custom parameters will be picked up by this package if they are defined as variables of **your project** within your `dbt_project.yml` file using the following syntax:
 
 ```
 [event name]_custom_parameters
@@ -105,7 +105,7 @@ For example:
 
 ```
 vars:
-  ga4:
+  <your_project>:
     page_view_custom_parameters:
       - name: "clean_event"
         value_type: "string_value"
@@ -117,7 +117,7 @@ You can optionally rename the output column:
 
 ```
 vars:
-  ga4:
+  <your_project>:
     page_view_custom_parameters:
       - name: "country_code"
         value_type: "int_value"
@@ -128,11 +128,12 @@ If there are custom parameters you need on all events, you can define defaults u
 
 ```
 vars:
-  ga4:
+  <your_project>:
     default_custom_parameters:
       - name: "country_code"
         value_type: "int_value"
 ```
+>Note: as _<your_project>_ you must use the value that You associated to the key **name:** (in dbt_project.yml)
 
 ### User Properties
 


### PR DESCRIPTION
In explanation of how to use the **Custom Parameters**, the doc shows that as project must be use **ga4:** (key  of second level of section **var:**).
But to use the _Custom Parameters_ with the models that I defined in the my project (that obivously uses the package ga4) I must said to _ga4_ that the model _\<my_model\>_ associated to that _Custom Parameters_ (_\<my_model\>\_custom_parameters_) is in **\<my_project\>** and not in **ga4**.

I propose this modify because i think that this aspect needs a more clear explanation.

- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [X] I have run `dbt test` and `python -m pytest .` to validate exists tests