### PR TITLE
Add page_path field

### DIFF
--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -9,3 +9,7 @@
 {% macro remove_query_parameters(url, parameters)%}
 REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{ parameters|join("|") }})=[^&]*', '\\1'), '\\?&+', '?'), '&+', '&'), '\\?$|&$', '')
 {% endmacro %}
+
+{% macro remove_query_string(url) %}
+REGEXP_REPLACE({{url}}, '\\?.*', '')
+{% endmacro %}

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -10,6 +10,6 @@
 REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{ parameters|join("|") }})=[^&]*', '\\1'), '\\?&+', '?'), '&+', '&'), '\\?$|&$', '')
 {% endmacro %}
 
-{% macro remove_query_string(url) %}
-REGEXP_REPLACE({{url}}, '\\?.*', '')
+{% macro extract_page_path(url) %}
+REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
 {% endmacro %}

--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -10,6 +10,7 @@ with session_first_event as
  session_start_dims as (
     select 
         session_key,
+        page_path as landing_page_path,
         page_location as landing_page,
         page_hostname as landing_page_hostname,
         page_referrer as landing_page_referrer,

--- a/models/marts/core/fct_ga4__pages.sql
+++ b/models/marts/core/fct_ga4__pages.sql
@@ -17,6 +17,7 @@ with page_view as (
         extract( hour from (select  timestamp_micros(event_timestamp))) as hour,
         page_location,  -- includes query string parameters not listed in query_parameter_exclusions variable
         page_key,
+        page_path,
         page_title,  -- would like to move this to dim_ga4__pages but need to think how to handle page_title changing over time
         count(event_name) as page_views,
         count(distinct user_pseudo_id ) as distinct_user_pseudo_ids,
@@ -25,7 +26,7 @@ with page_view as (
         sum(engagement_time_msec) as total_time_on_page 
         
 from {{ref('stg_ga4__event_page_view')}}
-    group by 1,2,3,4,5
+    group by 1,2,3,4,5,6
 ), scroll as (
     select
         event_date_dt,

--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -36,11 +36,13 @@ models:
         tests: 
           - unique
   - name: stg_ga4__events
-    description: Staging model that generates keys for users, sessions, and events
+    description: Staging model that generates keys for users, sessions, and events. Also parses URLs to remove query string params as defined in project config. 
     columns:
       - name: event_key
         tests:
           - unique
+      - name: page_path
+        description: This field contains the page_location with the query string portion removed. Uses macro remove_query_string
   - name: stg_ga4__event_scroll
     description: Staging model containing only 'scroll' events. Includes the 'percent_scrolled' parameter.
   - name: stg_ga4__derived_user_properties

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -52,7 +52,7 @@ remove_query_params as (
         * EXCEPT (page_location, page_referrer),
         page_location as original_page_location,
         page_referrer as original_page_referrer,
-        {{ remove_query_string('page_location') }} as page_path,
+        {{ extract_page_path('page_location') }} as page_path,
         -- If there are query parameters to exclude, exclude them using regex
         {% if var('query_parameter_exclusions',none) is not none %}
         {{remove_query_parameters('page_location',var('query_parameter_exclusions'))}} as page_location,

--- a/models/staging/ga4/stg_ga4__events.sql
+++ b/models/staging/ga4/stg_ga4__events.sql
@@ -52,6 +52,7 @@ remove_query_params as (
         * EXCEPT (page_location, page_referrer),
         page_location as original_page_location,
         page_referrer as original_page_referrer,
+        {{ remove_query_string('page_location') }} as page_path,
         -- If there are query parameters to exclude, exclude them using regex
         {% if var('query_parameter_exclusions',none) is not none %}
         {{remove_query_parameters('page_location',var('query_parameter_exclusions'))}} as page_location,


### PR DESCRIPTION
## Description & motivation
The GA4 API makes the distinction between `page path` and `page path with query string`. We have `original_page_location` which captures the full URL, but prior to this PR we did not have a way to group by `page_path` which removes the hostname and query string. 

Ex: `https://www.velir.com/my_page?foo=bar` becomes `/my_page`

Added the necessary macro and added the field to `stg_ga4__events`, `dim_ga4__sessions`, and `fct_ga4__pages`

## Checklist
- [x] I have verified that these changes work locally
- [na ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests