### PR TITLE
Dispatch the unnest_key macro

### DIFF
--- a/macros/unnest_key.sql
+++ b/macros/unnest_key.sql
@@ -1,13 +1,14 @@
 -- Unnests a single key's value from an array
 
 {%- macro unnest_key(column_to_unnest, key_to_extract, value_type = "string_value", rename_column = "default") -%}
+    {{ return(adapter.dispatch('unnest_key', 'ga4')(column_to_unnest, key_to_extract, value_type, rename_column)) }}
+{%- endmacro -%}
 
-(select value.{{value_type}} from unnest({{column_to_unnest}}) where key = '{{key_to_extract}}') as 
-
-    {% if  rename_column == "default" -%}
-    {{ key_to_extract }}
-    {%- else -%}
-    {{rename_column}}
-    {%- endif -%}
-
+{%- macro default__unnest_key(column_to_unnest, key_to_extract, value_type = "string_value", rename_column = "default") -%}
+    (select value.{{value_type}} from unnest({{column_to_unnest}}) where key = '{{key_to_extract}}') as 
+        {% if  rename_column == "default" -%}
+        {{ key_to_extract }}
+        {%- else -%}
+        {{rename_column}}
+        {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
## Description & motivation
As noted in #129, there are cases where event params can appears as multiple data types and package users may need custom logic to respond. This PR dispatches the `unnest_key` macro so that package users can implement their own logic for unnesting event params. See docs here for more on macro dispatching: https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch

Closes #129 

## Checklist
- [x] I have verified that these changes work locally
- [na ] I have updated the README.md (if applicable)
- [na ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests