### PR TITLE
Model determining whether a page_location and session combination reached 90% scroll

### DIFF
--- a/models/staging/ga4/stg_ga4.yml
+++ b/models/staging/ga4/stg_ga4.yml
@@ -83,4 +83,5 @@ models:
         tests:
           - not_null
           - unique
-
+  - name: stg_ga4__scroll_90_pct
+    description: Determines whether an individual page_location during an individual's session triggered a >=90 scroll or not.

--- a/models/staging/ga4/stg_ga4__scroll_90_pct.sql
+++ b/models/staging/ga4/stg_ga4__scroll_90_pct.sql
@@ -1,0 +1,9 @@
+-- Determines whether >=90% scroll was reached per date, page_location and session_key
+select
+    event_date_dt
+    , page_location
+    , session_key
+    , countif(percent_scrolled >= 90) > 1 as scroll_90_pct --true or false
+ from 
+    {{ref('stg_ga4__event_scroll')}}
+group by 1,2,3

--- a/models/staging/ga4/stg_ga4__scroll_90_pct.sql
+++ b/models/staging/ga4/stg_ga4__scroll_90_pct.sql
@@ -3,7 +3,7 @@ select
     event_date_dt
     , page_location
     , session_key
-    , countif(percent_scrolled >= 90) > 1 as scroll_90_pct --true or false
+    , countif(percent_scrolled >= 90) >= 1 as scroll_90_pct --true or false
  from 
     {{ref('stg_ga4__event_scroll')}}
 group by 1,2,3


### PR DESCRIPTION
## Description & motivation
While working on updates to the `pages` fact table, I realized that when simply counting the number of scroll events, you end up with an amount proportional to the granularity of tracking. For instance, if a user tracks scrolls at every percentage, you get a large count, but if they track scrolls at 25%/50%/75%/100% they get a small count. 

A better method would be to count the number of scroll events that reach a certain threshold (I'm suggesting 90% based on the OOB scroll tracking Google provides). This staging model measures whether a 90% scroll occurred per date, `page_location` and `session_key`.

Future work can incorporate this into fact tables. 


## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate exists tests