### PR TITLE
Add event_date_dt to stg_ga4__event_items

### DIFF
--- a/models/staging/ga4/stg_ga4__event_items.sql
+++ b/models/staging/ga4/stg_ga4__event_items.sql
@@ -2,6 +2,7 @@ with items_with_params as (
     select
         event_key,
         event_name,
+        event_date_dt,
         i.item_id,
         i.item_name,
         i.item_brand,


### PR DESCRIPTION
Add event_date_dt to stg_ga4__event_items to allow date partitioning of associated data marts

## Description & motivation
Data marts built on the `stg_ga4__event_items` view are strong candidates for date partitioning. This is hampered by the absence of a date field in the staging model. 

This PR fixes that oversight. 

## Checklist
- [ y] I have verified that these changes work locally
- [ n/a] I have updated the README.md (if applicable)
- [ n/a] I have added tests & descriptions to my models (and macros if applicable)
- [ y] I have run `dbt test` and `python -m pytest .` to validate exists tests