### PR TITLE
Add session_number field to dim_ga4_sessions

### DIFF
--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -38,6 +38,8 @@ with session_first_event as
         device_web_info_browser,
         device_web_info_browser_version,
         device_web_info_hostname,
+        session_number,
+        session_number = 1 as is_first_session,
         traffic_source_name,
         traffic_source_medium,
         traffic_source_source,

--- a/models/marts/core/fct_ga4__pages.sql
+++ b/models/marts/core/fct_ga4__pages.sql
@@ -21,7 +21,7 @@ with page_view as (
         page_title,  -- would like to move this to dim_ga4__pages but need to think how to handle page_title changing over time
         count(event_name) as page_views,
         count(distinct user_pseudo_id ) as distinct_user_pseudo_ids,
-        sum( if(ga_session_number = 1,1,0)) as new_user_pseudo_ids,
+        sum( if(session_number = 1,1,0)) as new_user_pseudo_ids,
         sum(entrances) as entrances,
         sum(engagement_time_msec) as total_time_on_page 
         

--- a/models/staging/ga4/base/base_ga4__events.sql
+++ b/models/staging/ga4/base/base_ga4__events.sql
@@ -128,7 +128,7 @@ renamed as (
         items,
         {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_location') }},
-        {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value') }},
+        {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value', 'session_number') }},
         (case when (SELECT value.string_value FROM unnest(event_params) WHERE key = "session_engaged") = "1" then 1 end) as session_engaged,
         {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_title') }},


### PR DESCRIPTION
## Description & motivation

- Renamed `ga_session_number` to `session_number` which I think will be more intuitive to users
- Added `session_number` to dim_ga4__sessions as well as an `is_first_session` flag

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate exists tests