### PR TITLE
CPC Campaign Attribution Fix

### DIFF
--- a/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/ga4/stg_ga4__sessions_traffic_sources.sql
@@ -11,6 +11,8 @@ with session_events as (
     from {{ref('stg_ga4__events')}}
     left join {{ref('ga4_source_categories')}} using (source)
     where session_key is not null
+    and event_name != 'session_start'
+    and event_name != 'first_visit'
    ),
 set_default_channel_grouping as (
     select


### PR DESCRIPTION
## Description & motivation
When a google / cpc visit arrives at a site, the first_visit and session_start events fire with a campaign set to '(cpc)' even when a utm_campaign is set to another value.  All other observed events use the utm_campaign value as desired.

The `stg_ga4__sessions_traffic_sources` model gets the first campaign value by timestamp that is not 'null' or '(direct)'. This results in a campaign value of '(cpc)' rather than the expected utm_campaign value.

Previous testing has not shown any issues with attribution when excluding first_visit and session_start events so I chose to exclude first_visit and session_start events from the `stg_ga4__sessions_traffic_sources` lookup.

This may also fix attribution outside of google / cpc campaigns, however these were not observed in the client dataset. 

## Checklist
- [y ] I have verified that these changes work locally
- [n/a ] I have updated the README.md (if applicable)
- [ n/a] I have added tests & descriptions to my models (and macros if applicable)
- [ y] I have run `dbt test` and `python -m pytest .` to validate existing tests
