### PR TITLE
Fix error with ga_session_number rename: consistent column name in base and intraday models

### DIFF
--- a/models/staging/ga4/base/base_ga4__events_intraday.sql
+++ b/models/staging/ga4/base/base_ga4__events_intraday.sql
@@ -91,7 +91,7 @@ renamed as (
         items,
         {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_location') }},
-        {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value') }},
+        {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value', 'session_number') }},
         (case when (SELECT value.string_value FROM unnest(event_params) WHERE key = "session_engaged") = "1" then 1 end) as session_engaged,
         {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }},
         {{ ga4.unnest_key('event_params', 'page_title') }},


### PR DESCRIPTION
## Description & motivation

It looks like #134 introduced a bug because I forgot to update the base_intraday mode. Fixed here and will merge ASAP.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
