### PR TITLE
Add push notifications channel

### DIFF
--- a/macros/default_channel_grouping.sql
+++ b/macros/default_channel_grouping.sql
@@ -50,6 +50,8 @@ case
     then 'Audio'
   when {{medium}} = 'sms'
     then 'SMS'
+  when REGEXP_CONTAINS({{medium}}, r"(mobile|notification|push$)") or {{source}} = 'firebase'
+    then 'Push Notifications'
   else '(Other)' 
 end 
 

--- a/unit_tests/test_macro_default_channel_grouping.py
+++ b/unit_tests/test_macro_default_channel_grouping.py
@@ -14,6 +14,8 @@ cn.bing.com,
 43things.com,
 alibaba,
 alibaba,cpc
+,push
+firebase,
 ,
 """.lstrip()
 
@@ -29,6 +31,8 @@ Organic Search
 Organic Social
 Organic Shopping
 Paid Shopping
+Push Notifications
+Push Notifications
 Direct
 """.lstrip()
 


### PR DESCRIPTION
## Description & motivation
The GA4 team has added the 'Mobile Push Notifications' channel group (see https://support.google.com/analytics/answer/9756891). This is an important channel for news outlets and other publishers that use push notifications.

I have renamed the channel from 'Mobile Push Notifications' to just 'Push Notifications' because 'push' is a common medium value for browser push notification services too.

This PR would close issue #151 with the channel name change.

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
