### PR TITLE
Macro to facilitate easy creation of custom events + params

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,27 @@ vars:
     conversion_events:['purchase','download']
 ```
 
+# Custom Events
+
+Custom events can be generated in your project using the `create_custom_event` macro. Simply create a new model in your project and enter the following:
+
+```
+{{ ga4.create_custom_event('my_custom_event') }}
+```
+
+Note, however, that any event-specific custom parameters or default custom parameters must be defined in your project's variable space. So if you project is named "jaffleshop", the following variable configuration will be used for the `my_custom_event` model:
+
+```
+vars:
+  jaffleshop:
+    default_custom_parameters:
+      - name: "some_parameter"
+        value_type: "string_value"
+    my_custom_event_custom_parameters:
+      - name: "some_other_parameter"
+        value_type: "string_value"
+```
+
 # Incremental Loading of Event Data (and how to handle late-arriving hits)
 
 By default, GA4 exports data into sharded event tables that use the event date as the table suffix in the format of `events_YYYYMMDD` or `events_intraday_YYYYMMDD`. This package incrementally loads data from these tables into `base_ga4__events` which is partitioned on date. There are two incremental loading strategies available:

--- a/README.md
+++ b/README.md
@@ -229,11 +229,10 @@ Custom events can be generated in your project using the `create_custom_event` m
 {{ ga4.create_custom_event('my_custom_event') }}
 ```
 
-Note, however, that any event-specific custom parameters or default custom parameters must be defined in your project's variable space. So if you project is named "jaffleshop", the following variable configuration will be used for the `my_custom_event` model:
+Note, however, that any event-specific custom parameters or default custom parameters must be defined in the global variable space as shown below:
 
 ```
 vars:
-  jaffleshop:
     default_custom_parameters:
       - name: "some_parameter"
         value_type: "string_value"

--- a/macros/create_custom_event.sql
+++ b/macros/create_custom_event.sql
@@ -1,0 +1,15 @@
+{%- macro create_custom_event(event_name) -%}
+    {{ return(adapter.dispatch('create_custom_event', 'ga4')(event_name)) }}
+{%- endmacro -%}
+
+{%- macro default__create_custom_event(event_name) -%}
+    select *
+        {% if var("default_custom_parameters", "none") != "none" %}
+            {{ ga4.stage_custom_parameters( var("default_custom_parameters", "none") )}}
+        {% endif %}
+        {% if var(event_name+"_custom_parameters", "none") != "none" %}
+            {{ ga4.stage_custom_parameters( var(event_name+"_custom_parameters") )}}
+        {% endif %}
+    from {{ref('stg_ga4__events')}}
+    where event_name = '{{event_name}}'
+{%- endmacro -%}


### PR DESCRIPTION
## Description & motivation
Currently, adding custom events requires copying/pasting code from the package which is not DRY. This PR adds a new macro, `create_custom_event` that can be pasted into a project model (along with an event name) and create the necessary event-specific model along with necessary event parameters.

```
{{ ga4.create_custom_event('newsletter_sign_up') }}
```

NOTE: It's required that the event's parameters and any 'default' parameters be assigned to the global namespace:

```
vars:
    default_custom_parameters:
      - name: "sitecore_item_id"
        value_type: "string_value"
    my_event_parameters:
      - name: "some_param"
        value_type: "string_value"
```

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
