### PR TITLE
Fix tab in base_ga4__events.yml causing parsing issue

### DIFF
--- a/models/staging/base/base_ga4__events.yml
+++ b/models/staging/base/base_ga4__events.yml
@@ -42,6 +42,6 @@ models:
       - name: platform
         description: The data stream platform (Web, IOS or Android) from which the event originated.
       - name: privacy_info_analytics_storage
-        description: 	Whether Analytics storage is enabled for the user. Possible values are Yes, No, Unset
+        description: Whether Analytics storage is enabled for the user. Possible values are Yes, No, Unset
       - name: privacy_info_ads_storage
         description: Whether ad targeting is enabled for a user. Possible values are Yes, No, Unset


### PR DESCRIPTION
The following error is corrected.
```
Parsing Error
  Error reading ga4: staging/base/base_ga4__events.yml - Runtime Error
    Syntax error near line 45
    ------------------------------
    42 |       - name: platform
    43 |         description: The data stream platform (Web, IOS or Android) from which the event originated.
    44 |       - name: privacy_info_analytics_storage
    45 |         description:   Whether Analytics storage is enabled for the user. Possible values are Yes, No, Unset
    46 |       - name: privacy_info_ads_storage
    47 |         description: Whether ad targeting is enabled for a user. Possible values are Yes, No, Unset
    
    Raw Error:
    ------------------------------
    while scanning for the next token
    found character '\t' that cannot start any token
      in "<unicode string>", line 45, column 22:
                description:    Whether Analytics storage is en ... 
```

## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
