### PR TITLE
add session start date/timestamp to session dim model

### DIFF
--- a/models/marts/core/dim_ga4__sessions.sql
+++ b/models/marts/core/dim_ga4__sessions.sql
@@ -10,6 +10,8 @@ with session_first_event as
  session_start_dims as (
     select 
         session_key,
+        event_date_dt as session_start_date,
+        event_timestamp as session_start_timestamp,
         page_path as landing_page_path,
         page_location as landing_page,
         page_hostname as landing_page_hostname,


### PR DESCRIPTION
## Description & motivation

Adds 2 fields to `dim_ga4__sessions` : 

```
        event_date_dt as session_start_date,
        event_timestamp as session_start_timestamp,
```

Should provide helpful context for the session. 

Closes #67 

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
