### PR TITLE
Incremental, partitioned session dim and fact tables. Allows for dimensional modeling on very large installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Features include:
 | stg_ga4__session_conversions_daily | Produces daily counts of conversions per session. The list of conversion events to include is configurable (see documentation below) |
 | stg_ga4__sessions_traffic_sources | Finds the first source, medium, campaign, content, paid search term (from UTM tracking), and default channel grouping for each session. |
 | dim_ga4__user_pseudo_ids | Dimension table for user devices as indicated by user_pseudo_ids. Contains attributes such as first and last page viewed.| 
-| dim_ga4__sessions | Dimension table for sessions which contains useful attributes such as geography, device information, and acquisition data |
+| dim_ga4__sessions | Dimension table for sessions which contains useful attributes such as geography, device information, and acquisition data. Can be expensive to run on large installs (see `dim_ga4__sessions_daily`) |
+| dim_ga4__sessions_daily | Query-optimized session dimension table that is incremental and partitioned on date. Assumes that each partition is contained within a single day |
 | fct_ga4__pages | Fact table for pages which aggregates common page metrics by page_location, date, and hour. |
 | fct_ga4__sessions_daily | Fact table for session metrics, partitioned by date. A single session may span multiple rows given that sessions can span multiple days.  |
 | fct_ga4__sessions | Fact table that aggregates session metrics across days. This table is not partitioned, so be mindful of performance/cost when querying. |

--- a/models/marts/core/core.yml
+++ b/models/marts/core/core.yml
@@ -19,12 +19,6 @@ models:
       - name: session_key
         tests:
           - unique
-  - name: fct_ga4__sessions_daily
-    description: Incremental session metrics model providing aggregate metrics per day such as number of pageviews and event value accrued. Each row represents 1 day of metrics for a single session. 
-    columns:
-      - name: session_partition_key
-        tests:
-          - unique
   - name: fct_ga4__pages
     description: Incremental model with page metrics such as visits, users, new_users, entrances and exits as well as configurable conversion counts. Each row is grouped by page_location, event_date_dt, and hour.
     columns:

--- a/models/marts/core/dim_ga4__sessions_daily.sql
+++ b/models/marts/core/dim_ga4__sessions_daily.sql
@@ -34,6 +34,7 @@
 with event_dimensions as 
 (
     select 
+        user_pseudo_id,
         session_key,
         session_partition_key,
         event_date_dt as session_partition_date,

--- a/models/marts/core/dim_ga4__sessions_daily.sql
+++ b/models/marts/core/dim_ga4__sessions_daily.sql
@@ -1,0 +1,155 @@
+{% if var('static_incremental_days', false ) %}
+    {% set partitions_to_replace = ['current_date'] %}
+    {% for i in range(var('static_incremental_days')) %}
+        {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+    {% endfor %}
+    {{
+        config(
+            materialized = 'incremental',
+            incremental_strategy = 'insert_overwrite',
+            tags = ["incremental"],
+            partition_by={
+                "field": "session_partition_date",
+                "data_type": "date",
+                "granularity": "day"
+            },
+            partitions = partitions_to_replace
+        )
+    }}
+{% else %}
+    {{
+        config(
+            materialized = 'incremental',
+            incremental_strategy = 'insert_overwrite',
+            tags = ["incremental"],
+            partition_by={
+                "field": "session_partition_date",
+                "data_type": "date",
+                "granularity": "day"
+            }
+        )
+    }}
+{% endif %}
+
+with event_dimensions as 
+(
+    select 
+        session_key,
+        session_partition_key,
+        event_date_dt as session_partition_date,
+        event_timestamp as session_partition_start_timestamp,
+        page_path,
+        page_location,
+        page_hostname,
+        page_referrer,
+        geo_continent,
+        geo_country,
+        geo_region,
+        geo_city,
+        geo_sub_continent,
+        geo_metro,
+        stream_id,
+        platform,
+        device_category,
+        device_mobile_brand_name,
+        device_mobile_model_name,
+        device_mobile_marketing_name,
+        device_mobile_os_hardware_model,
+        device_operating_system,
+        device_operating_system_version,
+        device_vendor_id,
+        device_advertising_id,
+        device_language,
+        device_is_limited_ad_tracking,
+        device_time_zone_offset_seconds,
+        device_browser,
+        device_web_info_browser,
+        device_web_info_browser_version,
+        device_web_info_hostname,
+        session_number,
+        session_number = 1 as is_first_session,
+        user_campaign,
+        user_medium,
+        user_source,
+    from {{ref('stg_ga4__events')}}
+    where event_name != 'first_visit' 
+    and event_name != 'session_start'
+    {% if is_incremental() %}
+        {% if var('static_incremental_days', false ) %}
+            and event_date_dt in ({{ partitions_to_replace | join(',') }})
+        {% else %}
+            and event_date_dt >= _dbt_max_partition
+        {% endif %}
+    {% endif %}
+),
+session_dimensions as 
+(
+    select    
+        session_key,
+        session_partition_key,
+        session_partition_date,
+        session_partition_start_timestamp,
+        FIRST_VALUE(page_path) IGNORE NULLS) OVER (session_partition_window) AS landing_page_path,,
+        landing_page,
+        landing_page_hostname,
+        landing_page_referrer,
+        geo_continent,
+        geo_country,
+        geo_region,
+        geo_city,
+        geo_sub_continent,
+        geo_metro,
+        stream_id,
+        platform,
+        device_category,
+        device_mobile_brand_name,
+        device_mobile_model_name,
+        device_mobile_marketing_name,
+        device_mobile_os_hardware_model,
+        device_operating_system,
+        device_operating_system_version,
+        device_vendor_id,
+        device_advertising_id,
+        device_language,
+        device_is_limited_ad_tracking,
+        device_time_zone_offset_seconds,
+        device_browser,
+        device_web_info_browser,
+        device_web_info_browser_version,
+        device_web_info_hostname,
+        session_number,
+        session_number = 1 as is_first_session,
+        user_campaign,
+        user_medium,
+        user_source,
+        
+        COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(event_medium, '(none)') END) IGNORE NULLS) OVER (session_partition_window), '(none)') AS session_medium,
+        from set_default_channel_grouping
+    WINDOW session_partition_window AS (PARTITION BY session_partition_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+)
+
+
+join_traffic_source as (
+    select 
+        session_start_dims.*,
+        sessions_traffic_sources.session_source,
+        sessions_traffic_sources.session_medium,
+        sessions_traffic_sources.session_campaign,
+        sessions_traffic_sources.session_content,
+        sessions_traffic_sources.session_term,
+        sessions_traffic_sources.session_default_channel_grouping,
+        sessions_traffic_sources.session_source_category
+    from session_start_dims
+    left join {{ref('stg_ga4__sessions_traffic_sources_daily')}} sessions_traffic_sources using (session_partition_key)
+),
+include_session_properties as (
+    select 
+        * 
+    from join_traffic_source
+    {% if var('derived_session_properties', false) %}
+    -- If derived session properties have been assigned as variables, join them on the session_key
+    left join {{ref('stg_ga4__derived_session_properties_daily')}} using (session_partition_key)
+    {% endif %}
+)
+
+select * from include_session_properties

--- a/models/marts/core/dim_ga4__sessions_daily.yml
+++ b/models/marts/core/dim_ga4__sessions_daily.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: dim_ga4__sessions_daily
+    description: Dimension table for sessions containing context useful for filtering such as acquisition source, medium, and campaign. Each row represents a session. Unique on session_key
+    columns:
+      - name: session_partition_key
+        tests:
+          - unique

--- a/models/marts/core/dim_ga4__sessions_daily.yml
+++ b/models/marts/core/dim_ga4__sessions_daily.yml
@@ -2,8 +2,21 @@ version: 2
 
 models:
   - name: dim_ga4__sessions_daily
-    description: Dimension table for sessions containing context useful for filtering such as acquisition source, medium, and campaign. Each row represents a session. Unique on session_key
+    description: >
+      Incremental, partitioned dimension table for session partitions. Partitioned on session_partition_date for improved query optimization when filtering on date. 
+      Contains context useful for filtering sessions such as acquisition source, medium, and campaign. 
+      Each row represents a daily session partition (as opposed to a session). 
+      Unique on session_partion_key
     columns:
       - name: session_partition_key
+        description: >
+          Unique key assigned to session partitions which are daily partitions of a session. In GA4, sessions can span multiple days. 
+          To improve query performance, it's easier to work with 'session partitions' which can be filtered/partitioned by date.
         tests:
           - unique
+      - name: session_key
+        description: >
+          Unique key assigned to sessions. Sessions can span multiple dates/partitions. 
+      - name: session_partition_date
+        description: >
+          Date associated with the session_partition_key. Used to partition the table. Filter on this column to optimize query cost and performance. 

--- a/models/marts/core/fct_ga4__sessions_daily.yml
+++ b/models/marts/core/fct_ga4__sessions_daily.yml
@@ -1,0 +1,10 @@
+version: 2
+
+models:  
+  - name: fct_ga4__sessions_daily
+    description: >
+      Incremental fact table with metrics related to daily session partitions.
+    columns:
+      - name: session_partition_key
+        tests:
+          - unique  

--- a/models/marts/core/fct_ga4__sessions_daily.yml
+++ b/models/marts/core/fct_ga4__sessions_daily.yml
@@ -6,5 +6,14 @@ models:
       Incremental fact table with metrics related to daily session partitions.
     columns:
       - name: session_partition_key
+        description: >
+          Unique key assigned to session partitions which are daily partitions of a session. In GA4, sessions can span multiple days. 
+          To improve query performance, it's easier to work with 'session partitions' which can be filtered/partitioned by date.
         tests:
-          - unique  
+          - unique
+      - name: session_key
+        description: >
+          Unique key assigned to sessions. Sessions can span multiple dates/partitions. 
+      - name: session_partition_date
+        description: >
+          Date associated with the session_partition_key. Used to partition the table. Filter on this column to optimize query cost and performance. 

--- a/models/staging/stg_ga4__derived_session_properties_daily.sql
+++ b/models/staging/stg_ga4__derived_session_properties_daily.sql
@@ -10,7 +10,7 @@
             incremental_strategy = 'insert_overwrite',
             tags = ["incremental"],
             partition_by={
-                "field": "session_start_date",
+                "field": "session_partition_date",
                 "data_type": "date",
                 "granularity": "day"
             },
@@ -25,7 +25,7 @@
             incremental_strategy = 'insert_overwrite',
             tags = ["incremental"],
             partition_by={
-                "field": "session_start_date",
+                "field": "session_partition_date",
                 "data_type": "date",
                 "granularity": "day"
             }
@@ -37,7 +37,7 @@ with unnest_event_params as
 (
     select 
         session_partition_key
-        ,event_date_dt as session_start_date
+        ,event_date_dt as session_partition_date
         ,event_timestamp
         {% for sp in var('derived_session_properties', []) %}
             {% if sp.user_property %}
@@ -60,7 +60,7 @@ with unnest_event_params as
 
 SELECT DISTINCT
     session_partition_key
-    ,session_start_date
+    ,session_partition_date
     {% for sp in var('derived_session_properties', []) %}
         , LAST_VALUE({{ sp.user_property | default(sp.event_parameter) }} IGNORE NULLS) OVER (session_window) AS {{ sp.session_property_name }}
     {% endfor %}

--- a/models/staging/stg_ga4__derived_session_properties_daily.sql
+++ b/models/staging/stg_ga4__derived_session_properties_daily.sql
@@ -5,12 +5,12 @@
     {% endfor %}
     {{
         config(
-            enabled= var('conversion_events', false) != false,
+            enabled = true if var('derived_session_properties', false) else false,
             materialized = 'incremental',
             incremental_strategy = 'insert_overwrite',
             tags = ["incremental"],
             partition_by={
-                "field": "session_partition_date",
+                "field": "session_start_date",
                 "data_type": "date",
                 "granularity": "day"
             },
@@ -20,12 +20,12 @@
 {% else %}
     {{
         config(
-            enabled= var('conversion_events', false) != false,
+            enabled = true if var('derived_session_properties', false) else false,
             materialized = 'incremental',
             incremental_strategy = 'insert_overwrite',
             tags = ["incremental"],
             partition_by={
-                "field": "session_partition_date",
+                "field": "session_start_date",
                 "data_type": "date",
                 "granularity": "day"
             }
@@ -33,17 +33,21 @@
     }}
 {% endif %}
 
-
-with event_counts as (
+with unnest_event_params as
+(
     select 
-        session_key,
-        session_partition_key,
-        min(event_date_dt) as session_partition_date -- The date of this partition, not necessarily the session start date given that sessions can span multiple days
-        {% for ce in var('conversion_events',[]) %}
-        , countif(event_name = '{{ce}}') as {{ce}}_count
+        session_partition_key
+        ,event_date_dt as session_start_date
+        ,event_timestamp
+        {% for sp in var('derived_session_properties', []) %}
+            {% if sp.user_property %}
+                , {{ ga4.unnest_key('user_properties', sp.user_property, sp.value_type) }}
+            {% else %}
+                , {{ ga4.unnest_key('event_params', sp.event_parameter, sp.value_type) }}
+            {% endif %}
         {% endfor %}
     from {{ref('stg_ga4__events')}}
-    where 1=1
+    where event_key is not null
     {% if is_incremental() %}
         {% if var('static_incremental_days', false ) %}
             and event_date_dt in ({{ partitions_to_replace | join(',') }})
@@ -51,7 +55,14 @@ with event_counts as (
             and event_date_dt >= _dbt_max_partition
         {% endif %}
     {% endif %}
-    group by 1,2
+
 )
 
-select * from event_counts
+SELECT DISTINCT
+    session_partition_key
+    ,session_start_date
+    {% for sp in var('derived_session_properties', []) %}
+        , LAST_VALUE({{ sp.user_property | default(sp.event_parameter) }} IGNORE NULLS) OVER (session_window) AS {{ sp.session_property_name }}
+    {% endfor %}
+FROM unnest_event_params
+WINDOW session_window AS (PARTITION BY session_partition_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)

--- a/models/staging/stg_ga4__derived_session_properties_daily.yml
+++ b/models/staging/stg_ga4__derived_session_properties_daily.yml
@@ -1,0 +1,11 @@
+version: 2
+
+models:  
+  - name: stg_ga4__derived_session_properties_daily
+    description: >
+      Optional model that will pull out the most recent instance of a particular event parameter for each session_partition_key. 
+      Later used in the fct_ga4__sessions_daily fact table.
+    columns:
+      - name: session_key
+        tests:
+          - unique  

--- a/models/staging/stg_ga4__derived_session_properties_daily.yml
+++ b/models/staging/stg_ga4__derived_session_properties_daily.yml
@@ -6,6 +6,6 @@ models:
       Optional model that will pull out the most recent instance of a particular event parameter for each session_partition_key. 
       Later used in the fct_ga4__sessions_daily fact table.
     columns:
-      - name: session_key
+      - name: session_partition_key
         tests:
-          - unique  
+          - unique

--- a/models/staging/stg_ga4__session_conversions_daily.sql
+++ b/models/staging/stg_ga4__session_conversions_daily.sql
@@ -38,7 +38,7 @@ with event_counts as (
     select 
         session_key,
         session_partition_key,
-        min(event_date_dt) as session_partition_date -- The date of this partition, not necessarily the session start date given that sessions can span multiple days
+        min(event_date_dt) as session_partition_date -- The date of this session partition
         {% for ce in var('conversion_events',[]) %}
         , countif(event_name = '{{ce}}') as {{ce}}_count
         {% endfor %}

--- a/models/staging/stg_ga4__sessions_traffic_sources_daily.sql
+++ b/models/staging/stg_ga4__sessions_traffic_sources_daily.sql
@@ -1,0 +1,80 @@
+{% if var('static_incremental_days', false ) %}
+    {% set partitions_to_replace = ['current_date'] %}
+    {% for i in range(var('static_incremental_days')) %}
+        {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+    {% endfor %}
+    {{
+        config(
+            materialized = 'incremental',
+            incremental_strategy = 'insert_overwrite',
+            tags = ["incremental"],
+            partition_by={
+                "field": "session_start_date",
+                "data_type": "date",
+                "granularity": "day"
+            },
+            partitions = partitions_to_replace
+        )
+    }}
+{% else %}
+    {{
+        config(
+            materialized = 'incremental',
+            incremental_strategy = 'insert_overwrite',
+            tags = ["incremental"],
+            partition_by={
+                "field": "session_start_date",
+                "data_type": "date",
+                "granularity": "day"
+            }
+        )
+    }}
+{% endif %}
+
+with session_events as (
+    select 
+        session_partition_key,
+        event_date_dt as session_start_date,
+        event_timestamp,
+        events.event_source,
+        event_medium,
+        event_campaign,
+        event_content,
+        event_term,
+        source_category
+    from {{ref('stg_ga4__events')}} events
+    left join {{ref('ga4_source_categories')}} source_categories on events.event_source = source_categories.source
+    where session_partition_key is not null
+    and event_name != 'session_start'
+    and event_name != 'first_visit'
+    {% if is_incremental() %}
+        {% if var('static_incremental_days', false ) %}
+            and event_date_dt in ({{ partitions_to_replace | join(',') }})
+        {% else %}
+            and event_date_dt >= _dbt_max_partition
+        {% endif %}
+    {% endif %}
+
+   ),
+set_default_channel_grouping as (
+    select
+        *,
+        {{ga4.default_channel_grouping('event_source','event_medium','source_category')}} as default_channel_grouping
+    from session_events
+),
+session_source as (
+    select    
+        session_partition_key,
+        session_start_date,
+        COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN event_source END) IGNORE NULLS) OVER (session_window), '(direct)') AS session_source,
+        COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(event_medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_medium,
+        COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_source_category,
+        COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(event_campaign, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_campaign,
+        COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(event_content, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_content,
+        COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(event_term, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_term,
+        COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(default_channel_grouping, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_default_channel_grouping
+    from set_default_channel_grouping
+    WINDOW session_window AS (PARTITION BY session_partition_key ORDER BY event_timestamp ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+)
+
+select distinct * from session_source

--- a/models/staging/stg_ga4__sessions_traffic_sources_daily.sql
+++ b/models/staging/stg_ga4__sessions_traffic_sources_daily.sql
@@ -9,7 +9,7 @@
             incremental_strategy = 'insert_overwrite',
             tags = ["incremental"],
             partition_by={
-                "field": "session_start_date",
+                "field": "session_partition_date",
                 "data_type": "date",
                 "granularity": "day"
             },
@@ -23,7 +23,7 @@
             incremental_strategy = 'insert_overwrite',
             tags = ["incremental"],
             partition_by={
-                "field": "session_start_date",
+                "field": "session_partition_date",
                 "data_type": "date",
                 "granularity": "day"
             }
@@ -34,7 +34,7 @@
 with session_events as (
     select 
         session_partition_key,
-        event_date_dt as session_start_date,
+        event_date_dt as session_partition_date,
         event_timestamp,
         events.event_source,
         event_medium,
@@ -65,7 +65,7 @@ set_default_channel_grouping as (
 session_source as (
     select    
         session_partition_key,
-        session_start_date,
+        session_partition_date,
         COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN event_source END) IGNORE NULLS) OVER (session_window), '(direct)') AS session_source,
         COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(event_medium, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_medium,
         COALESCE(FIRST_VALUE((CASE WHEN event_source <> '(direct)' THEN COALESCE(source_category, '(none)') END) IGNORE NULLS) OVER (session_window), '(none)') AS session_source_category,

--- a/models/staging/stg_ga4__sessions_traffic_sources_daily.yml
+++ b/models/staging/stg_ga4__sessions_traffic_sources_daily.yml
@@ -1,0 +1,17 @@
+version: 2
+
+models:  
+  - name: stg_ga4__sessions_traffic_sources_daily
+    description: >
+      Incremental model that finds the source of each session daily partition. Also adds the default channel grouping information. 
+      Uses the first non-null source value as the basis for selecting the event that will be used to assign source, medium, campaign, content, and term values. 
+      The session_start and first_visit events are ignored for this purpose as they contain no acquisition data. 
+      Aggregated by session_partition_key.
+    columns:
+      - name: session_partition_key
+        tests:
+          - unique
+      - name: session_source
+        description: First non-null source value of the session
+        tests:
+          - not_null

--- a/models/staging/stg_ga4__sessions_traffic_sources_daily.yml
+++ b/models/staging/stg_ga4__sessions_traffic_sources_daily.yml
@@ -3,7 +3,7 @@ version: 2
 models:  
   - name: stg_ga4__sessions_traffic_sources_daily
     description: >
-      Incremental model that finds the source of each session daily partition. Also adds the default channel grouping information. 
+      Incremental model that finds the acquisition source of each session day partition. 
       Uses the first non-null source value as the basis for selecting the event that will be used to assign source, medium, campaign, content, and term values. 
       The session_start and first_visit events are ignored for this purpose as they contain no acquisition data. 
       Aggregated by session_partition_key.


### PR DESCRIPTION
## Description & motivation
### Current Issue:
Building `dim_ga4__sessions` requires very expensive window functions that run against the entire event table. This is because GA4 sessions can span multiple days and the primary method available to us to reduce query cost is to incrementally work with N days of data. This causes a conflict: When working with N days of data, you may be working with the last-half of a session that started at an earlier date or working with the beginning-half of a session that ends at a later date. 

### Solution:
The only way to align a date-partitioned strategy with session dimensions is to revert to the assumption used by GA3 that sessions are wholly contained within a date. This PR adds a series of `_daily` models that make this assumption. Users of the package can make the decision whether they would like to work with multi-day sessions (at the expense of excess query costs) or daily sessions that are query-efficient. 

### Summary of changes:
- New concept: `session partition` which is a session split into date-grain records. A 2-day session will have 2 session partitions
- Added`stg_ga4__sessions_traffic_sources_daily` which finds acquisition sources for daily session partitions
- Added `stg_ga4__derived_session_properties_daily` which finds session properties within session partitions
- Added `dim_ga4__sessions_daily` which finds the first value of all dimension columns, windowing on session partition
- Made `stg_ga4__session_conversions_daily` incremental and partitioned (was already grouping by day)
- Made `fct_ga4__sessions_daily` incremental and partitioned

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
