### PR TITLE
Fix: Multi property sources from source database, not target database

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,20 +278,18 @@ Overriding the package's default channel mapping makes use of dbt's dispatch ove
 
 # Multi-Property Support
 
-Multiple GA4 properties are supported by listing out the project IDs in the `property_ids` variable as follows;
+Multiple GA4 properties are supported by listing out the project IDs in the `property_ids` variable. Requires that `static_incremental_days` be set as well.
 
 ```
 vars:
-  property_ids: [11111111, 22222222, 33333333]
+  ga4:
+    property_ids: [11111111, 22222222, 33333333]
+    static_incremental_days: 3
 ```
 
-In a multi-site implementation, the `dataset` variable should be set to a target dataset that will contain copies of each event shard from each property. It need not match an existing property ID. The `combine_property_data` macro will run as a pre-hook to `base_ga4_events` and clone shards to the target dataset based on the `static_incremental_days` variable. 
+In a multi-site implementation, the `dataset` variable should be set to a target dataset that will contain copies of each event shard from each property. The `combine_property_data` macro will run as a pre-hook to `base_ga4_events` and clone shards to the target dataset.  The number of days' worth of data to clone during incremental runs will be based on the `static_incremental_days` variable. 
 
-Jobs that run a large number of clone operations are prone to timing out. 
-
-As a result, it is recommended that you increase the query timeout if you need to backfill or full-refresh the table, when first setting up or when the base model gets modified.  
-
-Otherwise, it is best to prevent the base model from rebuilding on full refreshes unless needed to minimize timeouts.
+Jobs that run a large number of clone operations are prone to timing out. As a result, it is recommended that you increase the query timeout if you need to backfill or full-refresh the table, when first setting up or when the base model gets modified. Otherwise, it is best to prevent the base model from rebuilding on full refreshes unless needed to minimize timeouts.
 
 ```
 models:

--- a/macros/combine_property_data.sql
+++ b/macros/combine_property_data.sql
@@ -8,7 +8,7 @@
         
         {%- for property_id in var('property_ids') -%}
             {%- set schema_name = "analytics_" + property_id|string -%}
-            {%- set relations = dbt_utils.get_relations_by_pattern(schema_name, 'events_%') -%}
+            {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_%', exclude='events_intraday_%', database=var('project')) -%}
             {% for relation in relations %}
                 {%- set relation_suffix = relation.identifier|replace('events_', '') -%}
                 {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
@@ -20,7 +20,7 @@
     {% else %}
         {%- for property_id in var('property_ids') -%}
             {%- set schema_name = "analytics_" + property_id|string -%}
-            {%- set relations = dbt_utils.get_relations_by_pattern(schema_name, table_pattern='events_%', exclude='events_intraday_%') -%}
+            {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_%', exclude='events_intraday_%', database=var('project')) -%}
             {% for relation in relations %}
                 {%- set relation_suffix = relation.identifier|replace('events_', '') -%}
                 {%- if relation_suffix|int >= var('start_date')|int -%}


### PR DESCRIPTION
## Description & motivation
Previously, the `combine_property_data` macro used the target database in the `dbt_utils.get_relations_by_pattern` function to find tables to copy over. We needed to set the `database` parameter to `var('project')` to make sure it looked in the correct database. This was only an issue for users who use different databases for raw data and modeled data. 

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
