### PR TITLE
Warn instead of error when null page location

### DIFF
--- a/models/staging/events/stg_ga4__event_page_view.yml
+++ b/models/staging/events/stg_ga4__event_page_view.yml
@@ -6,4 +6,5 @@ models:
     columns: 
       - name: page_location
         tests:
-          - not_null
+          - not_null:
+              severity: warn


### PR DESCRIPTION
## Description & motivation
Closes #169 

It seems as though Google has changed their implementation recently as many including myself have started seeing null `page_location` values. Unclear on how this occurs, but it makes sense to change the column test to "warn" if this can occur in cases when there is no actionable implementation issue. 

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
