### PR TITLE
multi-site support for streaming frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Example:
 ```
 vars:
   ga4:
-    frequency:"daily+streaming"
+    frequency: "daily+streaming"
 ```
 
 # Connecting to BigQuery
@@ -310,6 +310,8 @@ vars:
 ```
 
 With these variables set, the `combine_property_data` macro will run as a pre-hook to `base_ga4_events` and clone shards to the target dataset.  The number of days' worth of data to clone during incremental runs will be based on the `static_incremental_days` variable. 
+
+Multiple-property installations treat the `"daily+streaming"` frequency setting as if it were set to `"daily"`.
 
 Jobs that run a large number of clone operations are prone to timing out. As a result, it is recommended that you increase the query timeout if you need to backfill or full-refresh the table, when first setting up or when the base model gets modified. Otherwise, it is best to prevent the base model from rebuilding on full refreshes unless needed to minimize timeouts.
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ vars:
 
 With these variables set, the `combine_property_data` macro will run as a pre-hook to `base_ga4_events` and clone shards to the target dataset.  The number of days' worth of data to clone during incremental runs will be based on the `static_incremental_days` variable. 
 
-Multiple-property installations treat the `"daily+streaming"` frequency setting as if it were set to `"daily"`.
+When the frequency variable is set to `daily` or `daily+streaming`, the `events_*` tables will be copied and intraday tables will be ignored. When the frequency is set to `streaming`, only the `events_intraday_*` tables will be copied.
 
 Jobs that run a large number of clone operations are prone to timing out. As a result, it is recommended that you increase the query timeout if you need to backfill or full-refresh the table, when first setting up or when the base model gets modified. Otherwise, it is best to prevent the base model from rebuilding on full refreshes unless needed to minimize timeouts.
 

--- a/macros/combine_property_data.sql
+++ b/macros/combine_property_data.sql
@@ -16,13 +16,22 @@
 
     {% for property_id in var('property_ids') %}
         {%- set schema_name = "analytics_" + property_id|string -%}
-        {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_%', exclude='events_intraday_%', database=var('project')) -%}
-        {% for relation in relations %}
-            {%- set relation_suffix = relation.identifier|replace('events_', '') -%}
-            {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
-                CREATE OR REPLACE TABLE `{{var('project')}}.{{var('dataset')}}.events_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_{{relation_suffix}}`;
-            {%- endif -%}
-        {% endfor %}
+        {%- if var('frequency', daily) == 'streaming' -%}
+            {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_intraday_%', database=var('project')) -%}
+            {% for relation in relations %}
+                {%- set relation_suffix = relation.identifier|replace('events_intraday_', '') -%}
+                {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
+                    CREATE OR REPLACE TABLE `{{var('project')}}.{{var('dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_intraday_{{relation_suffix}}`;
+                {%- endif -%}
+            {% endfor %}
+        {%- else -%}
+            {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_%', exclude='events_intraday_%', database=var('project')) -%}
+            {% for relation in relations %}
+                {%- set relation_suffix = relation.identifier|replace('events_', '') -%}
+                {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
+                    CREATE OR REPLACE TABLE `{{var('project')}}.{{var('dataset')}}.events_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_{{relation_suffix}}`;
+                {%- endif -%}
+            {% endfor %}
+        {%- endif -%}
     {% endfor %}
-
 {% endmacro %}


### PR DESCRIPTION
## Description & motivation

This PR adds streaming support for multi-property installations.

I could have unified the `events_` and `events_intraday_` code in the `combine_property_data` macro a little more writing both to `events_*` tables because, as things are currently written, daily and streaming frequencies are mutually exclusive and saved a couple lines of code. However, it is likely that supporting the daily+streaming frequency will require separation of code and it is easier to debug when they write to  `events_` and `events_intraday_` code.

## Checklist
- [ y] I have verified that these changes work locally
- [ y] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ y] I have run `dbt test` and `python -m pytest .` to validate existing tests
