### PR TITLE
add stream_id to stg_ga4__event_items

### DIFF
--- a/models/staging/stg_ga4__event_items.sql
+++ b/models/staging/stg_ga4__event_items.sql
@@ -3,6 +3,7 @@ with items_with_params as (
         event_key,
         event_name,
         event_date_dt,
+        stream_id,
         i.item_id,
         i.item_name,
         i.item_brand,


### PR DESCRIPTION
## Description & motivation

In a multi-site project, `stream_id` is useful to have when building models downstream of `stg_ga4__event_items` as it gives users the option to separate item data marts into different tables without having to reference other tables.

## Checklist
- [y ] I have verified that these changes work locally
- [n/a ] I have updated the README.md (if applicable)
- [ n/a] I have added tests & descriptions to my models (and macros if applicable)
- [ y] I have run `dbt test` and `python -m pytest .` to validate existing tests
