### PR TITLE
update package hub install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To pull the latest stable release along with minor updates, add the following to
 ```
 packages:
   - package: Velir/ga4
-    version: [">=3.0.0", "<3.2.0"]
+    version: [">=3.2.0", "<3.3.0"]
 ```
 
 ## Install From main branch on GitHub


### PR DESCRIPTION
## Description & motivation

Possibly related to !191, but our latest version is 3.2.1, but our instructions say to only install up to 3.2.0.


## Checklist
- [no ] I have verified that these changes work locally
- [yes ] I have updated the README.md (if applicable)
- [no ] I have added tests & descriptions to my models (and macros if applicable)
- [ no] I have run `dbt test` and `python -m pytest .` to validate existing tests
