### PR TITLE
Fix test on user_id_or_client_key in fct_ga4__user_ids model

### DIFF
--- a/models/marts/core/core.yml
+++ b/models/marts/core/core.yml
@@ -28,9 +28,3 @@ models:
         description: Hashed combination of user_pseudo_id and stream_id
         tests: 
           - unique
-  - name: fct_ga4__user_ids
-    description: Fact table with aggregate metrics at the level of the user_id when one is present, otherwise at the device level (as indicated by the client_key). Metrics are aggregated from fct_ga4__client_keys.
-    columns:
-      - name: user_id_or_client_key
-        tests: 
-          - unique

--- a/models/marts/core/fct_ga4__user_ids.yml
+++ b/models/marts/core/fct_ga4__user_ids.yml
@@ -1,0 +1,10 @@
+version: 2
+
+models:  
+  - name: fct_ga4__user_ids
+    description: Fact table with aggregate metrics at the level of the user_id when one is present, otherwise at the device level (as indicated by the client_key). Metrics are aggregated from fct_ga4__client_keys.
+    columns:
+      - name: user_id_or_client_key
+        tests: 
+          - unique:
+              column_name: "md5(user_id_or_client_key || stream_id)"

--- a/models/marts/core/fct_ga4__user_ids.yml
+++ b/models/marts/core/fct_ga4__user_ids.yml
@@ -5,6 +5,7 @@ models:
     description: Fact table with aggregate metrics at the level of the user_id when one is present, otherwise at the device level (as indicated by the client_key). Metrics are aggregated from fct_ga4__client_keys.
     columns:
       - name: user_id_or_client_key
-        tests: 
-          - unique:
-              column_name: "md5(user_id_or_client_key || stream_id)"
+    tests: 
+    - unique:
+        column_name: "md5(user_id_or_client_key || stream_id)"
+        


### PR DESCRIPTION
## Description & motivation
Closes #191

@TannerHopkins noticed that the uniqueness test for `fct_ga4__user_ids` can fail when joining together multiple data streams as it checks only the `user_id_or_client_key`. The `client_key` value already takes the `stream_id` values into account, but `user_id` does not. This means that sharing a `user_id` across streams would invalidate the test (despite being a valid outcome).

The test has been updated to incorporate `stream_id` in the uniqueness check. 

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
