### PR TITLE
partition pruning fct_ga4__pages

### DIFF
--- a/models/marts/core/fct_ga4__pages.sql
+++ b/models/marts/core/fct_ga4__pages.sql
@@ -27,9 +27,9 @@ with page_view as (
 from {{ref('stg_ga4__event_page_view')}}
 {% if is_incremental() %}
     {% if var('static_incremental_days', false)  %}
-        and event_date_dt in ({{ partitions_to_replace | join(',') }})
+        where event_date_dt in ({{ partitions_to_replace | join(',') }})
     {% else %}
-        and event_date_dt >= _dbt_max_partition
+        where event_date_dt >= _dbt_max_partition
     {% endif %}
 {% endif %}
     group by 1,2,3,4,5,6,7
@@ -50,9 +50,9 @@ from {{ref('stg_ga4__event_page_view')}}
     from {{ref('stg_ga4__event_scroll')}}
     {% if is_incremental() %}
         {% if var('static_incremental_days', false)  %}
-            and event_date_dt in ({{ partitions_to_replace | join(',') }})
+            where event_date_dt in ({{ partitions_to_replace | join(',') }})
         {% else %}
-            and event_date_dt >= _dbt_max_partition
+            where event_date_dt >= _dbt_max_partition
         {% endif %}
     {% endif %}
     group by 1,2,3

--- a/models/marts/core/fct_ga4__pages.sql
+++ b/models/marts/core/fct_ga4__pages.sql
@@ -1,13 +1,20 @@
+{% set partitions_to_replace = ['current_date'] %}
+{% if var('static_incremental_days', false)%}
+    {% for i in range(var('static_incremental_days')) %}
+        {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+    {% endfor %}
+{% endif %}
 {{
     config(
         materialized = 'incremental',
         incremental_strategy = 'insert_overwrite',
         tags = ["incremental"],
         partition_by={
-        "field": "event_date_dt",
-        "data_type": "date",
-        "granularity": "day"
-        }
+            "field": "event_date_dt",
+            "data_type": "date",
+            "granularity": "day"
+        },
+        partitions = partitions_to_replace
     )
 }}
 


### PR DESCRIPTION
## Description & motivation

The fct_ga4__pages model was missing is_incremental checks causing it to process more data than needed. This PR fixes that.

## Checklist
- [ y] I have verified that these changes work locally
- [n/a ] I have updated the README.md (if applicable)
- [n/a ] I have added tests & descriptions to my models (and macros if applicable)
- [ y] I have run `dbt test` and `python -m pytest .` to validate existing tests
