### PR TITLE
update standard ecommerce params

### DIFF
--- a/models/staging/recommended_events/stg_ga4__event_add_to_cart.sql
+++ b/models/staging/recommended_events/stg_ga4__event_add_to_cart.sql
@@ -5,6 +5,8 @@
 }}
  with add_to_cart_with_params as (
    select *except (items),
+   {{ ga4.unnest_key('event_params', 'currency') }},
+   {{ ga4.unnest_key('event_params', 'value', 'double_value') }},
    (select items FROM UNNEST(items) items LIMIT 1) as items
     {% if var("default_custom_parameters", "none") != "none" %}
       {{ ga4.stage_custom_parameters( var("default_custom_parameters") )}}

--- a/models/staging/recommended_events/stg_ga4__event_begin_checkout.sql
+++ b/models/staging/recommended_events/stg_ga4__event_begin_checkout.sql
@@ -5,6 +5,9 @@
 }}
  with begin_checkout_with_params as (
    select *
+   , {{ ga4.unnest_key('event_params', 'currency') }},
+   , {{ ga4.unnest_key('event_params', 'value', 'double_value') }},
+   , {{ ga4.unnest_key('event_params', 'coupon') }},
     {% if var("default_custom_parameters", "none") != "none" %}
       {{ ga4.stage_custom_parameters( var("default_custom_parameters") )}}
     {% endif %}

--- a/models/staging/recommended_events/stg_ga4__event_begin_checkout.sql
+++ b/models/staging/recommended_events/stg_ga4__event_begin_checkout.sql
@@ -5,9 +5,9 @@
 }}
  with begin_checkout_with_params as (
    select *
-   , {{ ga4.unnest_key('event_params', 'currency') }},
-   , {{ ga4.unnest_key('event_params', 'value', 'double_value') }},
-   , {{ ga4.unnest_key('event_params', 'coupon') }},
+   , {{ ga4.unnest_key('event_params', 'currency') }}
+   , {{ ga4.unnest_key('event_params', 'value', 'double_value') }}
+   , {{ ga4.unnest_key('event_params', 'coupon') }}
     {% if var("default_custom_parameters", "none") != "none" %}
       {{ ga4.stage_custom_parameters( var("default_custom_parameters") )}}
     {% endif %}

--- a/models/staging/recommended_events/stg_ga4__event_remove_from_cart.sql
+++ b/models/staging/recommended_events/stg_ga4__event_remove_from_cart.sql
@@ -4,8 +4,10 @@
   )
 }}
 with remove_from_cart_with_params as (
-  select * except (items),
-  (select items from unnest(items) items limit 1) as items
+  select * except (items)
+  , {{ ga4.unnest_key('event_params', 'currency') }}
+  , {{ ga4.unnest_key('event_params', 'value', 'double_value') }}
+  , (select items from unnest(items) items limit 1) as items
   {% if var("default_custom_parameters", "none") != "none" %}
     {{ ga4.stage_custom_parameters( var("default_custom_parameters") )}}
   {% endif %}

--- a/models/staging/recommended_events/stg_ga4__event_view_item.sql
+++ b/models/staging/recommended_events/stg_ga4__event_view_item.sql
@@ -4,8 +4,10 @@
   )
 }}
 with view_item_with_params as (
-  select * except (items),
-  (select items from unnest(items) items limit 1) as items
+  select * except (items)
+  , {{ ga4.unnest_key('event_params', 'currency') }}
+  , {{ ga4.unnest_key('event_params', 'value', 'double_value') }}
+  , (select items from unnest(items) items limit 1) as items
   {% if var("default_custom_parameters", "none") != "none" %}
     {{ ga4.stage_custom_parameters( var("default_custom_parameters") )}}
   {% endif %}

--- a/models/staging/recommended_events/stg_ga4__event_view_item_list.sql
+++ b/models/staging/recommended_events/stg_ga4__event_view_item_list.sql
@@ -5,6 +5,8 @@
 }}
 with view_item_list_with_params as (
   select *
+  , {{ ga4.unnest_key('event_params', 'item_list_id') }}
+  , {{ ga4.unnest_key('event_params', 'item_list_name') }}
   {% if var("default_custom_parameters", "none") != "none" %}
     {{ ga4.stage_custom_parameters( var("default_custom_parameters") )}}
   {% endif %}


### PR DESCRIPTION
## Description & motivation
I realize now that when I set up the first recommended events, I only included required fields as [documented here](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm). In other cases, I or others included fields that aren't required in the recommended events, like `item_list_name` and `item_list_id` in the `view_item_list` event.

This PR adds those non-required parameters to ecommerce events.

I realize now that we should have a discussion on how to handle it. We either only add the required fields and then make our documentation clear that fields that aren't marked as required need to be added as custom parameters, or we default to adding all of the parameters listed in the [recommended events docs](https://developers.google.com/analytics/devguides/collection/ga4/reference/events?client_type=gtm).

## Checklist
- [x] I have verified that these changes work locally
- [] I have updated the README.md (if applicable)
- [ n/a] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
