### PR TITLE
Allow columns to be renamed regarding conversion events

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,17 @@ vars:
     conversion_events:['purchase','download']
 ```
 
+By specifying `conversion_event_column_renamers`, you can optionally rename the output column. This can be used when the conversion event name is a special character that does not correspond to a column.
+
+```
+vars:
+  ga4:
+    conversion_events:['purchase(item)']
+    conversion_event_column_renamers:
+      purchase(item): "purchase_item"
+```
+
+
 ### Session Attribution Lookback Window
 
 The `stg_ga4__sessions_traffic_sources_last_non_direct_daily` model provides last non-direct session attribution within a configurable lookback window. The default is 30 days, but this can be overridden with the `session_attribution_lookback_window_days` variable.

--- a/macros/conversion_event_column_name.sql
+++ b/macros/conversion_event_column_name.sql
@@ -1,7 +1,7 @@
 {% macro conversion_event_column_name(event_name, prefix, suffix) %}
-  {% if var('conversion_event_renamers', false) and var('conversion_event_renamers')[event_name] %}
-    {{prefix}}{{var('conversion_event_renamers')[event_name]}}{{suffix}}
-  {% else %}
-    {{prefix}}{{event_name}}{{suffix}}
-  {% endif %}
+    {% if var('conversion_event_renamers', false) and var('conversion_event_renamers')[event_name] %}
+        {{prefix}}{{var('conversion_event_renamers')[event_name]}}{{suffix}}
+    {% else %}
+        {{prefix}}{{event_name}}{{suffix}}
+    {% endif %}
 {% endmacro %}

--- a/macros/conversion_event_column_name.sql
+++ b/macros/conversion_event_column_name.sql
@@ -1,6 +1,6 @@
 {% macro conversion_event_column_name(event_name, prefix, suffix) %}
-    {% if var('conversion_event_renamers', false) and var('conversion_event_renamers')[event_name] %}
-        {{prefix}}{{var('conversion_event_renamers')[event_name]}}{{suffix}}
+    {% if var('conversion_event_column_renamers', false) and var('conversion_event_column_renamers')[event_name] %}
+        {{prefix}}{{var('conversion_event_column_renamers')[event_name]}}{{suffix}}
     {% else %}
         {{prefix}}{{event_name}}{{suffix}}
     {% endif %}

--- a/macros/conversion_event_column_name.sql
+++ b/macros/conversion_event_column_name.sql
@@ -1,0 +1,7 @@
+{% macro conversion_event_column_name(event_name, prefix, suffix) %}
+  {% if var('conversion_event_renamers', false) and var('conversion_event_renamers')[event_name] %}
+    {{prefix}}{{var('conversion_event_renamers')[event_name]}}{{suffix}}
+  {% else %}
+    {{prefix}}{{event_name}}{{suffix}}
+  {% endif %}
+{% endmacro %}

--- a/models/marts/core/fct_ga4__client_keys.sql
+++ b/models/marts/core/fct_ga4__client_keys.sql
@@ -11,7 +11,7 @@ select
     count(distinct session_key)  as count_sessions
     {% if var('conversion_events', false) %}
         {% for ce in var('conversion_events',[]) %}
-            , sum(count_{{ce}}) as count_{{ce}}
+            , sum({{ga4.conversion_event_column_name(ce, 'count_', '')}}) as {{ga4.conversion_event_column_name(ce, 'count_', '')}}
         {% endfor %}
     {% endif %}
 from {{ref('fct_ga4__sessions')}}

--- a/models/marts/core/fct_ga4__sessions.sql
+++ b/models/marts/core/fct_ga4__sessions.sql
@@ -1,4 +1,4 @@
--- Stay mindful of performance/cost when using this model. Making this model partitioned on date is not possible because there's no way to create a single record per session AND partition on date. 
+-- Stay mindful of performance/cost when using this model. Making this model partitioned on date is not possible because there's no way to create a single record per session AND partition on date.
 
 select
     client_key,
@@ -15,7 +15,7 @@ select
     min(session_number) as session_number
     {% if var('conversion_events', false) %}
         {% for ce in var('conversion_events',[]) %}
-            , sum({{ce}}_count) as count_{{ce}}
+            , sum({{ga4.conversion_event_column_name(ce, '', '_count')}}) as {{ga4.conversion_event_column_name(ce, 'count_', '')}}
         {% endfor %}
     {% endif %}
 from {{ref('fct_ga4__sessions_daily')}}

--- a/models/marts/core/fct_ga4__user_ids.sql
+++ b/models/marts/core/fct_ga4__user_ids.sql
@@ -1,10 +1,10 @@
 with user_id_mapped as (
-    select 
+    select
         client_keys.*,
         -- Use a user_id if it exists, otherwise fall back to the client_key
         coalesce(user_id_mapping.last_seen_user_id, client_keys.client_key) as user_id_or_client_key,
         -- Indicate whether the user_id_or_client_key value is a user_id
-        CASE 
+        CASE
             WHEN user_id_mapping.last_seen_user_id is null THEN 0 ELSE 1
         END as is_user_id
     from {{ref('fct_ga4__client_keys')}} client_keys
@@ -25,7 +25,7 @@ select
     sum(count_sessions) as count_sessions
     {% if var('conversion_events', false) %}
         {% for ce in var('conversion_events',[]) %}
-            , sum(count_{{ce}}) as count_{{ce}}
+            , sum({{ga4.conversion_event_column_name(ce, 'count_', '')}}) as {{ga4.conversion_event_column_name(ce, 'count_', '')}}
         {% endfor %}
     {% endif %}
 from user_id_mapped

--- a/models/staging/stg_ga4__page_conversions.sql
+++ b/models/staging/stg_ga4__page_conversions.sql
@@ -2,10 +2,10 @@
   enabled= var('conversion_events', false) != false
 ) }}
 
-select 
+select
     page_key
     {% for ce in var('conversion_events',[]) %}
-    , countif(event_name = '{{ce}}') as {{ce}}_count
+    , countif(event_name = '{{ce}}') as {{ga4.conversion_event_column_name(ce, '', '_count')}}
     {% endfor %}
 from {{ref('stg_ga4__events')}}
 group by 1

--- a/models/staging/stg_ga4__session_conversions_daily.sql
+++ b/models/staging/stg_ga4__session_conversions_daily.sql
@@ -35,12 +35,12 @@
 
 
 with event_counts as (
-    select 
+    select
         session_key,
         session_partition_key,
         min(event_date_dt) as session_partition_date -- The date of this session partition
         {% for ce in var('conversion_events',[]) %}
-        , countif(event_name = '{{ce}}') as {{ce}}_count
+        , countif(event_name = '{{ce}}') as {{ga4.conversion_event_column_name(ce, '', '_count')}}
         {% endfor %}
     from {{ref('stg_ga4__events')}}
     where 1=1

--- a/unit_tests/test_stg_ga4__page_conversions.py
+++ b/unit_tests/test_stg_ga4__page_conversions.py
@@ -15,15 +15,7 @@ B,1
 
 actual = read_file('../models/staging/stg_ga4__page_conversions.sql')
 
-mock_macro = """
-{% macro conversion_event_column_name(event_name, prefix, suffix) %}
-    {% if var('conversion_event_renamers', false) and var('conversion_event_renamers')[event_name] %}
-        {{prefix}}{{var('conversion_event_renamers')[event_name]}}{{suffix}}
-    {% else %}
-        {{prefix}}{{event_name}}{{suffix}}
-    {% endif %}
-{% endmacro %}
-"""
+macro = read_file('../macros/conversion_event_column_name.sql')
 
 class TestPageConversions():
     # everything that goes in the "seeds" directory (= CSV format)
@@ -44,7 +36,7 @@ class TestPageConversions():
     @pytest.fixture(scope="class")
     def macros(self):
         return {
-            "conversion_event_column_name.sql": mock_macro
+            "conversion_event_column_name.sql": macro
         }
 
     def test_mock_run_and_check(self, project):

--- a/unit_tests/test_stg_ga4__page_conversions.py
+++ b/unit_tests/test_stg_ga4__page_conversions.py
@@ -15,6 +15,16 @@ B,1
 
 actual = read_file('../models/staging/stg_ga4__page_conversions.sql')
 
+mock_macro = """
+{% macro conversion_event_column_name(event_name, prefix, suffix) %}
+    {% if var('conversion_event_renamers', false) and var('conversion_event_renamers')[event_name] %}
+        {{prefix}}{{var('conversion_event_renamers')[event_name]}}{{suffix}}
+    {% else %}
+        {{prefix}}{{event_name}}{{suffix}}
+    {% endif %}
+{% endmacro %}
+"""
+
 class TestPageConversions():
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
@@ -30,7 +40,13 @@ class TestPageConversions():
         return {
             "actual.sql": actual,
         }
-    
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "conversion_event_column_name.sql": mock_macro
+        }
+
     def test_mock_run_and_check(self, project):
         run_dbt(["build", "--vars", "conversion_events: ['page_view']"])
         #breakpoint()

--- a/unit_tests/test_stg_ga4__session_conversions_daily.py
+++ b/unit_tests/test_stg_ga4__session_conversions_daily.py
@@ -20,6 +20,16 @@ A,A2022-01-02,2022-01-02,1
 
 actual = read_file('../models/staging/stg_ga4__session_conversions_daily.sql')
 
+mock_macro = """
+{% macro conversion_event_column_name(event_name, prefix, suffix) %}
+    {% if var('conversion_event_renamers', false) and var('conversion_event_renamers')[event_name] %}
+        {{prefix}}{{var('conversion_event_renamers')[event_name]}}{{suffix}}
+    {% else %}
+        {{prefix}}{{event_name}}{{suffix}}
+    {% endif %}
+{% endmacro %}
+"""
+
 class TestUsersFirstLastEvents():
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
@@ -35,7 +45,13 @@ class TestUsersFirstLastEvents():
         return {
             "actual.sql": actual,
         }
-    
+
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "conversion_event_column_name.sql": mock_macro
+        }
+
     def test_mock_run_and_check(self, project):
         run_dbt(["build", "--vars", "conversion_events: ['my_conversion']"])
         #breakpoint()

--- a/unit_tests/test_stg_ga4__session_conversions_daily.py
+++ b/unit_tests/test_stg_ga4__session_conversions_daily.py
@@ -20,15 +20,7 @@ A,A2022-01-02,2022-01-02,1
 
 actual = read_file('../models/staging/stg_ga4__session_conversions_daily.sql')
 
-mock_macro = """
-{% macro conversion_event_column_name(event_name, prefix, suffix) %}
-    {% if var('conversion_event_renamers', false) and var('conversion_event_renamers')[event_name] %}
-        {{prefix}}{{var('conversion_event_renamers')[event_name]}}{{suffix}}
-    {% else %}
-        {{prefix}}{{event_name}}{{suffix}}
-    {% endif %}
-{% endmacro %}
-"""
+macro = read_file('../macros/conversion_event_column_name.sql')
 
 class TestUsersFirstLastEvents():
     # everything that goes in the "seeds" directory (= CSV format)
@@ -49,7 +41,7 @@ class TestUsersFirstLastEvents():
     @pytest.fixture(scope="class")
     def macros(self):
         return {
-            "conversion_event_column_name.sql": mock_macro
+            "conversion_event_column_name.sql": macro
         }
 
     def test_mock_run_and_check(self, project):


### PR DESCRIPTION
## Description & motivation
### Current Issue:
Build of `stg_ga4__page_conversions` model fails when the value set for `conversion_events` is a special character that does not correspond to a column name.

### Soluton:
Define a new optional variable `conversion_event_column_renamers` whose key matches `conversion_events` and assign the column name renamed at query generation time.

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
