### PR TITLE
remove default purchase aggregations

### DIFF
--- a/models/marts/core/fct_ga4__client_keys.sql
+++ b/models/marts/core/fct_ga4__client_keys.sql
@@ -4,7 +4,6 @@ select
     min(session_start_timestamp) as first_seen_timestamp,
     min(session_start_date) as first_seen_start_date,
     sum(count_pageviews) as count_pageviews,
-    sum(count_purchases) as count_purchases,
     sum(is_session_engaged) as count_engaged_sessions,
     sum(sum_event_value_in_usd) as sum_event_value_in_usd,
     sum(sum_engaged_time_msec) as sum_engaged_time_msec,

--- a/models/marts/core/fct_ga4__sessions.sql
+++ b/models/marts/core/fct_ga4__sessions.sql
@@ -8,7 +8,6 @@ select
     min(session_partition_min_timestamp) as session_start_timestamp,
     min(session_partition_date) as session_start_date,
     sum(session_partition_count_page_views) as count_pageviews,
-    sum(session_partition_count_purchases) as count_purchases,
     sum(session_partition_sum_event_value_in_usd) as sum_event_value_in_usd,
     max(session_partition_max_session_engaged) as is_session_engaged,
     sum(session_partition_sum_engagement_time_msec) as sum_engaged_time_msec,

--- a/models/marts/core/fct_ga4__sessions_daily.sql
+++ b/models/marts/core/fct_ga4__sessions_daily.sql
@@ -41,7 +41,6 @@ with session_metrics as (
         min(event_date_dt) as session_partition_date, -- Date of the session partition, does not represent the true session start date which, in GA4, can span multiple days
         min(event_timestamp) as session_partition_min_timestamp,
         countif(event_name = 'page_view') as session_partition_count_page_views,
-        countif(event_name = 'purchase') as session_partition_count_purchases,
         sum(event_value_in_usd) as session_partition_sum_event_value_in_usd,
         ifnull(max(session_engaged), 0) as session_partition_max_session_engaged,
         sum(engagement_time_msec) as session_partition_sum_engagement_time_msec,
@@ -79,7 +78,6 @@ with session_metrics as (
             session_metrics.user_id,
             session_metrics.session_partition_min_timestamp,
             session_metrics.session_partition_count_page_views,
-            session_metrics.session_partition_count_purchases,
             session_metrics.session_partition_sum_event_value_in_usd,
             session_metrics.session_partition_max_session_engaged,
             session_metrics.session_partition_sum_engagement_time_msec,

--- a/models/marts/core/fct_ga4__user_ids.sql
+++ b/models/marts/core/fct_ga4__user_ids.sql
@@ -18,7 +18,6 @@ select
     min(first_seen_timestamp) as first_seen_timestamp,
     min(first_seen_start_date) as first_seen_start_date,
     sum(count_pageviews) as count_pageviews,
-    sum(count_purchases) as count_purchases,
     sum(count_engaged_sessions) as count_engaged_sessions,
     sum(sum_event_value_in_usd) as sum_event_value_in_usd,
     sum(sum_engaged_time_msec) as sum_engaged_time_msec,


### PR DESCRIPTION
## Description & motivation

Closes #203 

Removes the aggregation of `purchase` events from various mart models. This caused confusion when users added `purchase` as a conversion event.

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
