### PR TITLE
Correct README notes on derived session properties location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ vars:
 
 Derived session properties are similar to derived user properties, but on a per-session basis, for properties that change slowly over time. This provides additional flexibility in allowing users to turn any event parameter into a session property. 
 
-Derived Session Properties are included in the `dim_ga4__sessions` and `db_ga4__sessions_daily` models and contain the latest event parameter or user property value per session.
+Derived Session Properties are included in the `dim_ga4__sessions` and `dim_ga4__sessions_daily` models and contain the latest event parameter or user property value per session.
 
 ```
 derived_session_properties:

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ vars:
 
 Derived session properties are similar to derived user properties, but on a per-session basis, for properties that change slowly over time. This provides additional flexibility in allowing users to turn any event parameter into a session property. 
 
-Derived Session Properties are included in the `fct_ga4__sessions` model and contain the latest event parameter or user property value per session.
+Derived Session Properties are included in the `dim_ga4__sessions` and `db_ga4__sessions_daily` models and contain the latest event parameter or user property value per session.
 
 ```
 derived_session_properties:


### PR DESCRIPTION
## Description & motivation

The README was pointing me to the wrong location for derived session props; peeking through the code I found them on some other tables instead!

## Checklist

- [ ] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
