### PR TITLE
Remove all references to dynamic incremental load strategy

### DIFF
--- a/models/marts/core/fct_ga4__pages.sql
+++ b/models/marts/core/fct_ga4__pages.sql
@@ -1,9 +1,7 @@
 {% set partitions_to_replace = ['current_date'] %}
-{% if var('static_incremental_days', false)%}
-    {% for i in range(var('static_incremental_days')) %}
-        {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
-    {% endfor %}
-{% endif %}
+{% for i in range(var('static_incremental_days')) %}
+    {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+{% endfor %}
 {{
     config(
         materialized = 'incremental',
@@ -33,11 +31,7 @@ with page_view as (
         sum(entrances) as entrances,
 from {{ref('stg_ga4__event_page_view')}}
 {% if is_incremental() %}
-    {% if var('static_incremental_days', false)  %}
         where event_date_dt in ({{ partitions_to_replace | join(',') }})
-    {% else %}
-        where event_date_dt >= _dbt_max_partition
-    {% endif %}
 {% endif %}
     group by 1,2,3,4,5,6,7
 ), page_engagement as (
@@ -56,11 +50,7 @@ from {{ref('stg_ga4__event_page_view')}}
         count(event_name) as scroll_events
     from {{ref('stg_ga4__event_scroll')}}
     {% if is_incremental() %}
-        {% if var('static_incremental_days', false)  %}
             where event_date_dt in ({{ partitions_to_replace | join(',') }})
-        {% else %}
-            where event_date_dt >= _dbt_max_partition
-        {% endif %}
     {% endif %}
     group by 1,2,3
 )

--- a/models/staging/stg_ga4__sessions_traffic_sources_last_non_direct_daily.sql
+++ b/models/staging/stg_ga4__sessions_traffic_sources_last_non_direct_daily.sql
@@ -1,22 +1,20 @@
-{% if var('static_incremental_days',false) %}
-    {% set partitions_to_replace = ['current_date'] %}
-    {% for i in range(var('static_incremental_days',3)) %}
-        {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
-    {% endfor %}
-    {{
-        config(
-            materialized = 'incremental',
-            incremental_strategy = 'insert_overwrite',
-            tags = ["incremental"],
-            partition_by={
-                "field": "session_partition_date",
-                "data_type": "date",
-                "granularity": "day"
-            },
-            partitions = partitions_to_replace
-        )
-    }}
-{% endif %}
+{% set partitions_to_replace = ['current_date'] %}
+{% for i in range(var('static_incremental_days',3)) %}
+    {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+{% endfor %}
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'insert_overwrite',
+        tags = ["incremental"],
+        partition_by={
+            "field": "session_partition_date",
+            "data_type": "date",
+            "granularity": "day"
+        },
+        partitions = partitions_to_replace
+    )
+}}
 
 with last_non_direct_session_partition_key as (
   select

--- a/models/staging/stg_ga4__sessions_traffic_sources_last_non_direct_daily.sql
+++ b/models/staging/stg_ga4__sessions_traffic_sources_last_non_direct_daily.sql
@@ -1,5 +1,5 @@
 {% set partitions_to_replace = ['current_date'] %}
-{% for i in range(var('static_incremental_days',3)) %}
+{% for i in range(var('static_incremental_days')) %}
     {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
 {% endfor %}
 {{

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -26,4 +26,7 @@ def dbt_profile_target():
 
 @pytest.fixture(scope="class")
 def project_config_update():
-    return {'name': 'ga4'}
+    return {
+            'name': 'ga4'
+            , 'vars':{'static_incremental_days':3}
+            }

--- a/unit_tests/test_stg_ga4__sessions_traffic_sources_last_non_direct_daily.py
+++ b/unit_tests/test_stg_ga4__sessions_traffic_sources_last_non_direct_daily.py
@@ -31,9 +31,10 @@ class TestSessionsTrafficSourcesLastNonDirectDaily():
     @pytest.fixture(scope="class")
     def models(self):
         return {
-            "actual.sql": actual,
+            # Hack-y solution to ensure the model is not partitioned. Loading mock data (date columns) from a seed file + partitioning don't work well together. 
+            "actual.sql": actual.replace("materialized = 'incremental',","materialized = 'view',"),
         }
     
     def test_mock_run_and_check(self, project):
-        run_dbt(["build"])
+        run_dbt(["build", "--vars", "static_incremental_days: 3"])
         check_relations_equal(project.adapter, ["actual", "expected"])

--- a/unit_tests/test_stg_ga4__sessions_traffic_sources_last_non_direct_daily.py
+++ b/unit_tests/test_stg_ga4__sessions_traffic_sources_last_non_direct_daily.py
@@ -36,5 +36,5 @@ class TestSessionsTrafficSourcesLastNonDirectDaily():
         }
     
     def test_mock_run_and_check(self, project):
-        run_dbt(["build", "--vars", "static_incremental_days: 3"])
+        run_dbt(["build"])
         check_relations_equal(project.adapter, ["actual", "expected"])


### PR DESCRIPTION
## Description & motivation
Closes #239 

After refactoring daily/streaming support, there were remaining references to the 'dynamic incremental load' strategy that has been replaced with the 'static' strategy. This PR removes those references.

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
