### PR TITLE
Allow range of dbt_utils versions

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: 1.1.1
+    version: [">=1.0.0", "<2.0.0"]


### PR DESCRIPTION
## Description & motivation

PR for ticket: https://github.com/Velir/dbt-ga4/issues/241 .

Since this package is not using safe_subtract, it doesn't require dbt 1.1 (and certainly doesn't require 1.1.1 which is just a readme change).  On the other hand, future versions before 2.0 are not supposed to be breaking changes, so it should be safe to allow them.  Allowing a broad range of dbt_utils versions makes it much easier for companies to use this package along with other packages that also have dbt_utils version requirements.

## Checklist
- [X] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable) (N/A)
- [ ] I have added tests & descriptions to my models (and macros if applicable) (N/A)
- [X] I have run `dbt test` and `python -m pytest .` to validate existing tests
