### PR TITLE
basic xclid concept

### DIFF
--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -13,3 +13,7 @@ REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{
 {% macro extract_page_path(url) %}
 REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
 {% endmacro %}
+
+{% macro extract_query_parameter_value(url, param) %}
+    REGEXP_EXTRACT( {{url}}, r'{{param}}=([^&|\?|#]*)'  )
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation
Resolves #234 

The purpose of this PR is to give users the option to configure whatever click IDs that they want to track like `gclid`, `fbclid` as well as numerous other attribution and ad platform click IDs.

Todo: 
- integrate into session tables
- optimize per comment below
- add tests

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
