### PR TITLE
check for intraday table before processing union operation

### DIFF
--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -2,6 +2,9 @@
 {% for i in range(var('static_incremental_days')) %}
     {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
 {% endfor %}
+{% if var('property_ids', false) == false %}
+    {% set relations_intraday = dbt_utils.get_relations_by_pattern(schema_pattern=var('dataset'), table_pattern='events_intraday_%', database=var('project')) %} 
+{% endif %}
 {{
     config(
         pre_hook="{{ ga4.combine_property_data() }}" if var('property_ids', false) else "",
@@ -26,25 +29,34 @@ with source_daily as (
         and parse_date('%Y%m%d', left(_TABLE_SUFFIX, 8)) in ({{ partitions_to_replace | join(',') }})
     {% endif %}
 ),
-source_intraday as (
-    select 
-        {{ ga4.base_select_source() }}
-        from {{ source('ga4', 'events_intraday') }}
-        where cast( _table_suffix as int64) >= {{var('start_date')}}
-    {% if is_incremental() %}
-        and parse_date('%Y%m%d', left(_TABLE_SUFFIX, 8)) in ({{ partitions_to_replace | join(',') }})
-    {% endif %}
-),
-unioned as (
-    select * from source_daily
-        union all
-    select * from source_intraday
-),
-renamed as (
-    select 
-        {{ ga4.base_select_renamed() }}
-    from unioned
-)
+-- Include intraday data if using a single-property configuration and the events_intraday_* table exists 
+{% if var('property_ids', false) == false and relations_intraday|length > 0 %}
+    source_intraday as (
+        select 
+            {{ ga4.base_select_source() }}
+            from {{ source('ga4', 'events_intraday') }}
+            where cast( _table_suffix as int64) >= {{var('start_date')}}
+        {% if is_incremental() %}
+            and parse_date('%Y%m%d', left(_TABLE_SUFFIX, 8)) in ({{ partitions_to_replace | join(',') }})
+        {% endif %}
+    ),
+    unioned as (
+        select * from source_daily
+            union all
+        select * from source_intraday
+    ),
+    renamed as (
+        select 
+            {{ ga4.base_select_renamed() }}
+        from unioned
+    )
+{% else %}
+    renamed as (
+        select 
+            {{ ga4.base_select_renamed() }}
+        from source_daily
+    )
+{% endif%}
 
 select * from renamed
 qualify row_number() over(partition by event_date_dt, stream_id, user_pseudo_id, session_id, event_name, event_timestamp, to_json_string(event_params)) = 1


### PR DESCRIPTION
## Description & motivation
Resolves #249

When implementing #238, a bug was introduced whereby the base events model would attempt to union intraday data even if it did not exist.

This PR uses the dbt.utils `dbt_utils.get_relations_by_pattern` function to evaluate whether the intraday table exists before attempting to union its data. It only does this check when NOT combining data from multiple properties (the combine_property_data macro has its own check to see if the intraday table exists)

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
