### PR TITLE
fix combine property data to drop old intraday tables

### DIFF
--- a/macros/combine_property_data.sql
+++ b/macros/combine_property_data.sql
@@ -17,7 +17,7 @@
 
     {% for property_id in var('property_ids') %}
         {%- set schema_name = "analytics_" + property_id|string -%}
-            {# Copy daily tables #}
+            {# Copy intraday tables #}
             {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_intraday_%', database=var('project')) -%}
             {% for relation in relations %}
                 {%- set relation_suffix = relation.identifier|replace('events_intraday_', '') -%}
@@ -25,12 +25,13 @@
                     CREATE OR REPLACE TABLE `{{var('project')}}.{{var('dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_intraday_{{relation_suffix}}`;
                 {%- endif -%}
             {% endfor %}
-            {# Copy intraday tables #}
+            {# Copy daily tables and drop old intraday table #}
             {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_%', exclude='events_intraday_%', database=var('project')) -%}
             {% for relation in relations %}
                 {%- set relation_suffix = relation.identifier|replace('events_', '') -%}
                 {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
                     CREATE OR REPLACE TABLE `{{var('project')}}.{{var('dataset')}}.events_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_{{relation_suffix}}`;
+                    DROP TABLE IF EXISTS `{{var('project')}}.{{var('dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}`
                 {%- endif -%}
             {% endfor %}
     {% endfor %}

--- a/macros/combine_property_data.sql
+++ b/macros/combine_property_data.sql
@@ -31,7 +31,7 @@
                 {%- set relation_suffix = relation.identifier|replace('events_', '') -%}
                 {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
                     CREATE OR REPLACE TABLE `{{var('project')}}.{{var('dataset')}}.events_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_{{relation_suffix}}`;
-                    DROP TABLE IF EXISTS `{{var('project')}}.{{var('dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}`
+                    DROP TABLE IF EXISTS `{{var('project')}}.{{var('dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}`;
                 {%- endif -%}
             {% endfor %}
     {% endfor %}


### PR DESCRIPTION
## Description & motivation
Resolves #255 

This PR drops old intraday tables in case their equivalent daily table becomes available and has been copied to the combined dataset.
It fixes the issue of:
* data duplication that is not sufficiently resolved by the deduplication in `base_ga4__events`
* waste of storage (and cost) of intraday tables clones


## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
