### PR TITLE
Fix streaming support for multi property configurations

### DIFF
--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -2,7 +2,9 @@
 {% for i in range(var('static_incremental_days')) %}
     {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
 {% endfor %}
-{% set relations_intraday = dbt_utils.get_relations_by_pattern(schema_pattern=var('dataset'), table_pattern='events_intraday_%', database=var('project')) %} 
+{% if var('property_ids', false) == false %}
+    {% set relations_intraday = dbt_utils.get_relations_by_pattern(schema_pattern=var('dataset'), table_pattern='events_intraday_%', database=var('project')) %} 
+{% endif %}
 {{
     config(
         pre_hook="{{ ga4.combine_property_data() }}" if var('property_ids', false) else "",
@@ -28,7 +30,7 @@ with source_daily as (
     {% endif %}
 ),
 -- Include intraday data if using a single-property configuration and the events_intraday_* table exists 
-{% if relations_intraday|length > 0 %}
+{% if var('property_ids', false) == false and relations_intraday|length > 0 %}
     source_intraday as (
         select 
             {{ ga4.base_select_source() }}

--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -2,9 +2,7 @@
 {% for i in range(var('static_incremental_days')) %}
     {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
 {% endfor %}
-{% if var('property_ids', false) == false %}
-    {% set relations_intraday = dbt_utils.get_relations_by_pattern(schema_pattern=var('dataset'), table_pattern='events_intraday_%', database=var('project')) %} 
-{% endif %}
+
 {{
     config(
         pre_hook="{{ ga4.combine_property_data() }}" if var('property_ids', false) else "",
@@ -19,44 +17,20 @@
     )
 }}
 
-with source_daily as (
+with source as (
     select 
         {{ ga4.base_select_source() }}
         from {{ source('ga4', 'events') }}
-        where _table_suffix not like '%intraday%'
-        and cast( _table_suffix as int64) >= {{var('start_date')}}
+        where cast( replace(_table_suffix, 'intraday_', '') as int64) >= {{var('start_date')}}
     {% if is_incremental() %}
         and parse_date('%Y%m%d', left(_TABLE_SUFFIX, 8)) in ({{ partitions_to_replace | join(',') }})
     {% endif %}
 ),
--- Include intraday data if using a single-property configuration and the events_intraday_* table exists 
-{% if var('property_ids', false) == false and relations_intraday|length > 0 %}
-    source_intraday as (
-        select 
-            {{ ga4.base_select_source() }}
-            from {{ source('ga4', 'events_intraday') }}
-            where cast( _table_suffix as int64) >= {{var('start_date')}}
-        {% if is_incremental() %}
-            and parse_date('%Y%m%d', left(_TABLE_SUFFIX, 8)) in ({{ partitions_to_replace | join(',') }})
-        {% endif %}
-    ),
-    unioned as (
-        select * from source_daily
-            union all
-        select * from source_intraday
-    ),
-    renamed as (
-        select 
-            {{ ga4.base_select_renamed() }}
-        from unioned
-    )
-{% else %}
-    renamed as (
-        select 
-            {{ ga4.base_select_renamed() }}
-        from source_daily
-    )
-{% endif%}
+renamed as (
+    select 
+        {{ ga4.base_select_renamed() }}
+    from source
+)
 
 select * from renamed
 qualify row_number() over(partition by event_date_dt, stream_id, user_pseudo_id, session_id, event_name, event_timestamp, to_json_string(event_params)) = 1

--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -2,9 +2,7 @@
 {% for i in range(var('static_incremental_days')) %}
     {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
 {% endfor %}
-{% if var('property_ids', false) == false %}
-    {% set relations_intraday = dbt_utils.get_relations_by_pattern(schema_pattern=var('dataset'), table_pattern='events_intraday_%', database=var('project')) %} 
-{% endif %}
+{% set relations_intraday = dbt_utils.get_relations_by_pattern(schema_pattern=var('dataset'), table_pattern='events_intraday_%', database=var('project')) %} 
 {{
     config(
         pre_hook="{{ ga4.combine_property_data() }}" if var('property_ids', false) else "",
@@ -30,7 +28,7 @@ with source_daily as (
     {% endif %}
 ),
 -- Include intraday data if using a single-property configuration and the events_intraday_* table exists 
-{% if var('property_ids', false) == false and relations_intraday|length > 0 %}
+{% if relations_intraday|length > 0 %}
     source_intraday as (
         select 
             {{ ga4.base_select_source() }}

--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -23,7 +23,7 @@ with source as (
         from {{ source('ga4', 'events') }}
         where cast( replace(_table_suffix, 'intraday_', '') as int64) >= {{var('start_date')}}
     {% if is_incremental() %}
-        and parse_date('%Y%m%d', left(_TABLE_SUFFIX, 8)) in ({{ partitions_to_replace | join(',') }})
+        and parse_date('%Y%m%d', left( replace(_table_suffix, 'intraday_', ''), 8)) in ({{ partitions_to_replace | join(',') }})
     {% endif %}
 ),
 renamed as (

--- a/models/staging/src_ga4.yml
+++ b/models/staging/src_ga4.yml
@@ -8,6 +8,3 @@ sources:
       - name: events
         identifier: events_* # Scan across all sharded event tables. Use the 'start_date' variable to limit this scan
         description: Main events table exported by GA4. Sharded by date. 
-      - name: events_intraday
-        identifier: events_intraday_*
-        description: Intraday events table which is optionally exported by GA4.


### PR DESCRIPTION
## Description & motivation
Resolves #254 

As noted by @FlorianASchroeder , PR #250 allowed the union of intraday data only for single-property configurations. 

This update removes that limitation by leveraging the fact that both daily and intraday event tables start with 'events_'. This means we can use a wildcard operation to query `events_*` to pull both daily and intraday records. Duplicate records will be deduped as part of the `base_ga4__events` qualify statement. 

As a result, we can remove the intraday source from `src_ga4.yml`

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
