### PR TITLE
feat: Add ability to override the extract_page_path macro

### DIFF
--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -17,9 +17,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v4
         with:
-          python-version: "3.11.x"
+          python-version: "3.x"
 
       - name: Authenticate using service account
         run: 'echo "$KEYFILE" > ./dbt-service-account.json'

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.7.x"
+          python-version: "3.8.x"
 
       - name: Authenticate using service account
         run: 'echo "$KEYFILE" > ./dbt-service-account.json'

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -17,6 +17,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Get current date
+        id: date
+        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_ENV
+
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x" 

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.8.x"
+          python-version: "3.7.x"
 
       - name: Authenticate using service account
         run: 'echo "$KEYFILE" > ./dbt-service-account.json'

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install dbt-core
-          pip install dbt-bigquery
+          pip install dbt-bigquery==1.5.6
           pip install pytest
       
       - name: Run tests

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.x" 
 
       - name: Authenticate using service account
         run: 'echo "$KEYFILE" > ./dbt-service-account.json'

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.8.x"
+          python-version: "3.11.x"
 
       - name: Authenticate using service account
         run: 'echo "$KEYFILE" > ./dbt-service-account.json'
@@ -30,7 +30,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install dbt-core
-          pip install dbt-bigquery==1.5.6
+          pip install dbt-bigquery
           pip install pytest
       
       - name: Run tests

--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -17,10 +17,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-      - name: Get current date
-        id: date
-        run: echo "CURRENT_DATE=$(date +'%Y-%m-%d_%H-%M-%S')" >> $GITHUB_ENV
-
       - uses: actions/setup-python@v4
         with:
           python-version: "3.x" 

--- a/README.md
+++ b/README.md
@@ -293,11 +293,6 @@ Package users can override this macro and implement their own channel groupings 
 
 Overriding the package's default channel mapping makes use of dbt's dispatch override capability documented here: https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch#overriding-package-macros
 
-# Overriding Page Path Parsing
-By default, this package assumes valid URLs and parses the page path from the URL using a specific regex pattern.
-
-Similar to above, package users can override this macro by creating a macro in your project names `default__extract_page_path` that accepts a url argument.
-
 # Multi-Property Support
 
 Multiple GA4 properties are supported by listing out the project IDs in the `property_ids` variable. In this scenario, the `static_incremental_days` variable is required and the `dataset` variable will define the target dataset where source data will be copied.

--- a/README.md
+++ b/README.md
@@ -293,6 +293,11 @@ Package users can override this macro and implement their own channel groupings 
 
 Overriding the package's default channel mapping makes use of dbt's dispatch override capability documented here: https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch#overriding-package-macros
 
+# Overriding Page Path Parsing
+By default, this package assumes valid URLs and parses the page path from the URL using a specific regex pattern.
+
+Similar to above, package users can override this macro by creating a macro in your project names `default__extract_page_path` that accepts a url argument.
+
 # Multi-Property Support
 
 Multiple GA4 properties are supported by listing out the project IDs in the `property_ids` variable. In this scenario, the `static_incremental_days` variable is required and the `dataset` variable will define the target dataset where source data will be copied.

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -11,11 +11,7 @@ REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{
 {% endmacro %}
 
 {% macro extract_page_path(url) %}
-  {{ return(adapter.dispatch('extract_page_path', 'ga4')(url)) }}
-{% endmacro %}
-
-{% macro default__extract_page_path(url) %}
-   REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
+  REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
 {% endmacro %}
 
 {% macro extract_query_parameter_value(url, param) %}

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -11,11 +11,7 @@ REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{
 {% endmacro %}
 
 {% macro extract_page_path(url) %}
-  {{ return(adapter.dispatch('extract_page_path', 'ga4')(url)) }}
-{% endmacro %}
-
-{% macro default__extract_page_path(url) %}
-   REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
+REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
 {% endmacro %}
 
 {% macro extract_query_parameter_value(url, param) %}

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -11,7 +11,11 @@ REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{
 {% endmacro %}
 
 {% macro extract_page_path(url) %}
-REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
+  {{ return(adapter.dispatch('extract_page_path', 'ga4')(url)) }}
+{% endmacro %}
+
+{% macro default__extract_page_path(url) %}
+   REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
 {% endmacro %}
 
 {% macro extract_query_parameter_value(url, param) %}

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -11,7 +11,11 @@ REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{
 {% endmacro %}
 
 {% macro extract_page_path(url) %}
-  REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
+  {{ return(adapter.dispatch('extract_page_path', 'ga4')(url)) }}
+{% endmacro %}
+
+{% macro default__extract_page_path(url) %}
+   REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
 {% endmacro %}
 
 {% macro extract_query_parameter_value(url, param) %}

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -7,7 +7,7 @@
 {% endmacro %}
 
 {% macro remove_query_parameters(url, parameters)%}
-REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{ parameters|join("|") }})=[^&]*', '\\1'), '\\?&+', '?'), '&+', '&'), '\\?$|&$', '')
+    REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{ parameters|join("|") }})=[^&]*', '\\1'), '\\?&+', '?'), '&+', '&'), '\\?$|&$', '')
 {% endmacro %}
 
 {% macro extract_page_path(url) %}

--- a/unit_tests/test_stg_ga4__users_first_last_events.py
+++ b/unit_tests/test_stg_ga4__users_first_last_events.py
@@ -11,7 +11,7 @@ expected_csv = """client_key,first_event,last_event,stream_id,first_geo_continen
 IX+OyYJBgjwqML19GB/XIQ==,H06dLW6OhNJJ6SoEPFsSyg==,gt1SoAtrxDv33uDGwVeMVA==,1,Asia,India,Maharashtra,Mumbai,Southern Asia,(not set),desktop,Google,Chrome,,,Windows,Windows 10,,,en-us,No,,,,Chrome,104.0.0.0,www.velir.com,,,,USA,Massachusetts,Maharashtra,Mumbai,Southern Asia,(not set),mobile,Google,Chrome,,,Windows,Windows 10,,,en-us,No,,,,Chrome,104.0.0.0,www.velir.com,,,
 """.lstrip()
 
-actual = read_file('../models/staging/stg_ga4__client_key_first_last_events.sql')
+actual = read_file('models/staging/stg_ga4__client_key_first_last_events.sql')
 
 class TestUsersFirstLastEvents():
     # everything that goes in the "seeds" directory (= CSV format)


### PR DESCRIPTION
## Description & motivation
Some URLs are not valid and therefore the base `extract_page_path` macro does not work. This update will allow users to override the macro with their own

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
