### PR TITLE
Add adapter dispatch pattern for path extraction

### DIFF
--- a/.github/workflows/run_unit_tests_on_pr.yml
+++ b/.github/workflows/run_unit_tests_on_pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: "3.7.x"
+          python-version: "3.11.x"
 
       - name: Authenticate using service account
         run: 'echo "$KEYFILE" > ./dbt-service-account.json'

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -11,7 +11,11 @@ REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{
 {% endmacro %}
 
 {% macro extract_page_path(url) %}
-REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
+  {{ return(adapter.dispatch('extract_page_path', 'ga4')(url)) }}
+{% endmacro %}
+
+{% macro default__extract_page_path(url) %}
+   REGEXP_EXTRACT({{url}}, '(?:\\w+:)?\\/\\/[^\\/]+([^?#]+)')
 {% endmacro %}
 
 {% macro extract_query_parameter_value(url, param) %}


### PR DESCRIPTION
## Description & motivation
It can be helpful for users of the package to override the page path extraction to accommodate implementation issues. This PR applies the adapter dispatch pattern to the `extract_page_path` macro.

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
