### PR TITLE
Dedup transactions

### DIFF
--- a/models/staging/recommended_events/README.md
+++ b/models/staging/recommended_events/README.md
@@ -28,3 +28,13 @@ models:
 ```
 
 Not all recommended events have been implemented. If you need a specific event, please consider creating a pull request with the model that you need in the [dbt-ga4 GitHub repository](https://github.com/Velir/dbt-ga4).
+
+## Purchase Event Transaction Deduplication
+
+The `stg_ga4__event_purchase_deduplicated` model builds on the `sgt_ga4__event_purchase` model. It is disabled by default and thus needs to be enabled along with the `stg_ga4__event_purchase` model.
+
+The model only processes purchase events that fall within the window as defined by `static_incremental_days` and can only reliably be expected to deduplicate purchase events occurring in the same day.
+
+The model provides a highly-performant, minimum-viable product for this feature returning only data from the first purchase event with a matching `transaction_id` within the processing window.
+
+You are encouraged to copy this model to your project and customize it there should this MVP be insufficient for your needs.

--- a/models/staging/recommended_events/stg_ga4__event_purchase_deduplicated.sql
+++ b/models/staging/recommended_events/stg_ga4__event_purchase_deduplicated.sql
@@ -17,22 +17,11 @@ with purch as (
     {% if not flags.FULL_REFRESH %}
         where event_date_dt in ({{ partitions_to_query | join(',') }})
     {% endif %}
-)
-, dedup as (
-    /*  this is intended to be the maximally performant MVP for transaction deduplication
-        it is possible that you may want to roll up various purchase parameters and not just event_key where later events contain late-arriving parameters
-        in cases like this, use this model as a template and make your customizations in your project */ 
-    select distinct
-        first_value(event_key ignore nulls) over (transaction_window) as event_key   
-    from purch
-    window transaction_window as (
-        partition by transaction_id 
-        order by 
-            event_timestamp asc rows between unbounded preceding
-            and unbounded following
-    )
+    qualify row_number() over(
+        partition by transaction_id
+            order by event_timestamp
+    ) = 1
 )
 select
-    purch.*
-from dedup
-left join purch on dedup.event_key = purch.event_key
+    *
+from purch

--- a/models/staging/recommended_events/stg_ga4__event_purchase_deduplicated.sql
+++ b/models/staging/recommended_events/stg_ga4__event_purchase_deduplicated.sql
@@ -1,0 +1,19 @@
+{{
+  config(
+      enabled = false,
+  )
+}}
+with purch as (
+    select
+        *
+    from {{ref('stg_ga4__event_purchase')}}
+)
+select
+    first_value(* ignore nulls) over (transaction_window)
+from purch
+window transaction_window as (
+    partition by transaction_id 
+    order by 
+        event_timestamp asc rows between {{var('static_incremental_days', 3 ) * 24 * 60 * 60 * 1000000 }} preceding
+        and unbounded following
+        )

--- a/models/staging/recommended_events/stg_ga4__event_purchase_deduplicated.sql
+++ b/models/staging/recommended_events/stg_ga4__event_purchase_deduplicated.sql
@@ -8,12 +8,21 @@ with purch as (
         *
     from {{ref('stg_ga4__event_purchase')}}
 )
+, dedup as (
+    /*  this is intended to be the maximally performant MVP for transaction deduplication
+        it is possible that you may want to roll up various purchase parameters and not just event_key where later events contain late-arriving parameters
+        in cases like this, use this model as a template and make your customizations in your project */ 
+    select
+        first_value(event_key ignore nulls) over (transaction_window) as event_key   
+    from purch
+    window transaction_window as (
+        partition by transaction_id 
+        order by 
+            event_timestamp asc rows between {{var('static_incremental_days', 3 ) * 24 * 60 * 60 * 1000000 }} preceding
+            and unbounded following
+    )
+)
 select
-    first_value(* ignore nulls) over (transaction_window)
-from purch
-window transaction_window as (
-    partition by transaction_id 
-    order by 
-        event_timestamp asc rows between {{var('static_incremental_days', 3 ) * 24 * 60 * 60 * 1000000 }} preceding
-        and unbounded following
-        )
+    purch.*
+from dedup
+left join purch on dedup.event_key = purch.event_key

--- a/models/staging/recommended_events/stg_ga4__event_purchase_deduplicated.sql
+++ b/models/staging/recommended_events/stg_ga4__event_purchase_deduplicated.sql
@@ -12,7 +12,7 @@ with purch as (
     /*  this is intended to be the maximally performant MVP for transaction deduplication
         it is possible that you may want to roll up various purchase parameters and not just event_key where later events contain late-arriving parameters
         in cases like this, use this model as a template and make your customizations in your project */ 
-    select
+    select distinct
         first_value(event_key ignore nulls) over (transaction_window) as event_key   
     from purch
     window transaction_window as (


### PR DESCRIPTION
## Description & motivation
Resolves #193.

This PR deduplicates transactions on `transaction_id`  within  the current processing window as determined by the `static_incremental_days` variable.

There are a number of possible issues could be fixed here but many of them are in conflict with one another so I chose to keep this as simple as possible.

## Checklist
- [y ] I have verified that these changes work locally
- [ y] I have updated the README.md (if applicable)
- [n/a ] I have added tests & descriptions to my models (and macros if applicable)
- [ y] I have run `dbt test` and `python -m pytest .` to validate existing tests
