### PR TITLE
Explicit Item and Ecommerce field selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ packages:
 packages:
   - local: ../dbt-ga4
 ```
+## Version Upgrade
+Since the release of version `5.0.0`, Google changed format of the `items` record which caused the `base_ga4__events` model to fail. This was fixed with a simple full refresh, but that cost extra processing.
+
+Version `5.1.0` explicitly unnests and re-nests the `items` and `ecommerce` records in the `base_ga4__events` model so that future changes will not break the model.
+
+Every effort has been made to re-nest the contents of those records into the same slots which should ensure that you can upgrade without rebuilding your `base_ga4__events` table. However, if you run in to an error with the `base_ga4__events` model on upgrading, you will need to run a full refresh to fix the error.
+
 ## Required Variables
 
 This package assumes that you have an existing DBT project with a BigQuery profile and a BigQuery GCP instance available with GA4 event data loaded. Source data is defined using the `project` and `dataset` variables below. The `static_incremental_days` variable defines how many days' worth of data to reprocess during incremental runs. 

--- a/README.md
+++ b/README.md
@@ -70,13 +70,6 @@ packages:
 packages:
   - local: ../dbt-ga4
 ```
-## Version Upgrade
-Since the release of version `5.0.0`, Google changed format of the `items` record which caused the `base_ga4__events` model to fail. This was fixed with a simple full refresh, but that cost extra processing.
-
-Version `5.1.0` explicitly unnests and re-nests the `items` and `ecommerce` records in the `base_ga4__events` model so that future changes will not break the model.
-
-Every effort has been made to re-nest the contents of those records into the same slots which should ensure that you can upgrade without rebuilding your `base_ga4__events` table. However, if you run in to an error with the `base_ga4__events` model on upgrading, you will either need to run a full refresh to fix the error or over-ride the `base_select` macro with your own version where the order of the `items` and `ecommerce` fields matches that seen in your existing `base_ga4__events` table.
-
 ## Required Variables
 
 This package assumes that you have an existing DBT project with a BigQuery profile and a BigQuery GCP instance available with GA4 event data loaded. Source data is defined using the `project` and `dataset` variables below. The `static_incremental_days` variable defines how many days' worth of data to reprocess during incremental runs. 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Since the release of version `5.0.0`, Google changed format of the `items` recor
 
 Version `5.1.0` explicitly unnests and re-nests the `items` and `ecommerce` records in the `base_ga4__events` model so that future changes will not break the model.
 
-Every effort has been made to re-nest the contents of those records into the same slots which should ensure that you can upgrade without rebuilding your `base_ga4__events` table. However, if you run in to an error with the `base_ga4__events` model on upgrading, you will need to run a full refresh to fix the error.
+Every effort has been made to re-nest the contents of those records into the same slots which should ensure that you can upgrade without rebuilding your `base_ga4__events` table. However, if you run in to an error with the `base_ga4__events` model on upgrading, you will either need to run a full refresh to fix the error or over-ride the `base_select` macro with your own version where the order of the `items` and `ecommerce` fields matches that seen in your existing `base_ga4__events` table.
 
 ## Required Variables
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'ga4'
-version: '5.0.0'
+version: '5.1.0'
 config-version: 2
 model-paths: ["models"]
 analysis-paths: ["analyses"]

--- a/macros/base_select.sql
+++ b/macros/base_select.sql
@@ -31,6 +31,7 @@
     ecommerce.shipping_value_in_usd,
     ecommerce.shipping_value,
     ecommerce.tax_value_in_usd,
+    ecommerce.tax_value,
     ecommerce.unique_items,
     ecommerce.transaction_id,
     items,
@@ -100,6 +101,7 @@
         , shipping_value_in_usd
         , shipping_value
         , tax_value_in_usd
+        , tax_value
         , unique_items
         , transaction_id        
     ) as ecommerce,
@@ -118,6 +120,8 @@
             , unnested_items.price
             , unnested_items.quantity
             , unnested_items.item_revenue_in_usd
+            , unnested_items.item_revenue
+            , unnested_items.item_refund_in_usd
             , unnested_items.item_refund
             , unnested_items.coupon
             , unnested_items.affiliation

--- a/macros/base_select.sql
+++ b/macros/base_select.sql
@@ -23,7 +23,16 @@
     traffic_source,
     stream_id,
     platform,
-    ecommerce,
+    ecommerce.total_item_quantity,
+    ecommerce.purchase_revenue_in_usd,
+    ecommerce.purchase_revenue,
+    ecommerce.refund_value_in_usd,
+    ecommerce.refund_value,
+    ecommerce.shipping_value_in_usd,
+    ecommerce.shipping_value,
+    ecommerce.tax_value_in_usd,
+    ecommerce.unique_items,
+    ecommerce.transaction_id,
     items,
 {% endmacro %}
 
@@ -82,8 +91,47 @@
     traffic_source.source as user_source,
     stream_id,
     platform,
-    ecommerce,
-    items,
+    struct(
+        total_item_quantity
+        , purchase_revenue_in_usd
+        , purchase_revenue
+        , refund_value_in_usd
+        , refund_value
+        , shipping_value_in_usd
+        , shipping_value
+        , tax_value_in_usd
+        , unique_items
+        , transaction_id        
+    ) as ecommerce,
+    (select 
+        array_agg(struct(
+            unnested_items.item_id
+            , unnested_items.item_name
+            , unnested_items.item_brand
+            , unnested_items.item_variant
+            , unnested_items.item_category
+            , unnested_items.item_category2
+            , unnested_items.item_category3
+            , unnested_items.item_category4
+            , unnested_items.item_category5
+            , unnested_items.price_in_usd
+            , unnested_items.price
+            , unnested_items.quantity
+            , unnested_items.item_revenue_in_usd
+            , unnested_items.item_refund
+            , unnested_items.coupon
+            , unnested_items.affiliation
+            , unnested_items.location_id
+            , unnested_items.item_list_id
+            , unnested_items.item_list_name
+            , unnested_items.item_list_index
+            , unnested_items.promotion_id
+            , unnested_items.promotion_name
+            , unnested_items.creative_name
+            , unnested_items.creative_slot
+            , unnested_items.item_params
+        )) from unnest(items) as unnested_items 
+    ) items,
     {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value', 'session_id') }},
     {{ ga4.unnest_key('event_params', 'page_location') }},
     {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value', 'session_number') }},

--- a/macros/base_select.sql
+++ b/macros/base_select.sql
@@ -3,38 +3,38 @@
 {% endmacro %}
 
 {% macro default__base_select_source() %}
-    parse_date('%Y%m%d',event_date) as event_date_dt,
-    event_timestamp,
-    event_name,
-    event_params,
-    event_previous_timestamp,
-    event_value_in_usd,
-    event_bundle_sequence_id,
-    event_server_timestamp_offset,
-    user_id,
-    user_pseudo_id,
-    privacy_info,
-    user_properties,
-    user_first_touch_timestamp,
-    user_ltv,
-    device,
-    geo,
-    app_info,
-    traffic_source,
-    stream_id,
-    platform,
-    ecommerce.total_item_quantity,
-    ecommerce.purchase_revenue_in_usd,
-    ecommerce.purchase_revenue,
-    ecommerce.refund_value_in_usd,
-    ecommerce.refund_value,
-    ecommerce.shipping_value_in_usd,
-    ecommerce.shipping_value,
-    ecommerce.tax_value_in_usd,
-    ecommerce.tax_value,
-    ecommerce.unique_items,
-    ecommerce.transaction_id,
-    items,
+    parse_date('%Y%m%d',event_date) as event_date_dt
+    , event_timestamp
+    , event_name
+    , event_params
+    , event_previous_timestamp
+    , event_value_in_usd
+    , event_bundle_sequence_id
+    , event_server_timestamp_offset
+    , user_id
+    , user_pseudo_id
+    , privacy_info
+    , user_properties
+    , user_first_touch_timestamp
+    , user_ltv
+    , device
+    , geo
+    , app_info
+    , traffic_source
+    , stream_id
+    , platform
+    , ecommerce.total_item_quantity
+    , ecommerce.purchase_revenue_in_usd
+    , ecommerce.purchase_revenue
+    , ecommerce.refund_value_in_usd
+    , ecommerce.refund_value
+    , ecommerce.shipping_value_in_usd
+    , ecommerce.shipping_value
+    , ecommerce.tax_value_in_usd
+    , ecommerce.tax_value
+    , ecommerce.unique_items
+    , ecommerce.transaction_id
+    , items
 {% endmacro %}
 
 {% macro base_select_renamed() %}
@@ -42,57 +42,57 @@
 {% endmacro %}
 
 {% macro default__base_select_renamed() %}
-    event_date_dt,
-    event_timestamp,
-    lower(replace(trim(event_name), " ", "_")) as event_name, -- Clean up all event names to be snake cased
-    event_params,
-    event_previous_timestamp,
-    event_value_in_usd,
-    event_bundle_sequence_id,
-    event_server_timestamp_offset,
-    user_id,
-    user_pseudo_id,
-    privacy_info.analytics_storage as privacy_info_analytics_storage,
-    privacy_info.ads_storage as privacy_info_ads_storage,
-    privacy_info.uses_transient_token as privacy_info_uses_transient_token,
-    user_properties,
-    user_first_touch_timestamp,
-    user_ltv.revenue as user_ltv_revenue,
-    user_ltv.currency as user_ltv_currency,
-    device.category as device_category,
-    device.mobile_brand_name as device_mobile_brand_name,
-    device.mobile_model_name as device_mobile_model_name,
-    device.mobile_marketing_name as device_mobile_marketing_name,
-    device.mobile_os_hardware_model as device_mobile_os_hardware_model,
-    device.operating_system as device_operating_system,
-    device.operating_system_version as device_operating_system_version,
-    device.vendor_id as device_vendor_id,
-    device.advertising_id as device_advertising_id,
-    device.language as device_language,
-    device.is_limited_ad_tracking as device_is_limited_ad_tracking,
-    device.time_zone_offset_seconds as device_time_zone_offset_seconds,
-    device.browser as device_browser,
-    device.browser_version as device_browser_version,
-    device.web_info.browser as device_web_info_browser,
-    device.web_info.browser_version as device_web_info_browser_version,
-    device.web_info.hostname as device_web_info_hostname,
-    geo.continent as geo_continent,
-    geo.country as geo_country,
-    geo.region as geo_region,
-    geo.city as geo_city,
-    geo.sub_continent as geo_sub_continent,
-    geo.metro as geo_metro,
-    app_info.id as app_info_id,
-    app_info.version as app_info_version,
-    app_info.install_store as app_info_install_store,
-    app_info.firebase_app_id as app_info_firebase_app_id,
-    app_info.install_source as app_info_install_source,
-    traffic_source.name as user_campaign,
-    traffic_source.medium as user_medium,
-    traffic_source.source as user_source,
-    stream_id,
-    platform,
-    struct(
+    event_date_dt
+    , event_timestamp
+    , lower(replace(trim(event_name), " ", "_")) as event_name -- Clean up all event names to be snake cased
+    , event_params
+    , event_previous_timestamp
+    , event_value_in_usd
+    , event_bundle_sequence_id
+    , event_server_timestamp_offset
+    , user_id
+    , user_pseudo_id
+    , privacy_info.analytics_storage as privacy_info_analytics_storage
+    , privacy_info.ads_storage as privacy_info_ads_storage
+    , privacy_info.uses_transient_token as privacy_info_uses_transient_token
+    , user_properties
+    , user_first_touch_timestamp
+    , user_ltv.revenue as user_ltv_revenue
+    , user_ltv.currency as user_ltv_currency
+    , device.category as device_category
+    , device.mobile_brand_name as device_mobile_brand_name
+    , device.mobile_model_name as device_mobile_model_name
+    , device.mobile_marketing_name as device_mobile_marketing_name
+    , device.mobile_os_hardware_model as device_mobile_os_hardware_model
+    , device.operating_system as device_operating_system
+    , device.operating_system_version as device_operating_system_version
+    , device.vendor_id as device_vendor_id
+    , device.advertising_id as device_advertising_id
+    , device.language as device_language
+    , device.is_limited_ad_tracking as device_is_limited_ad_tracking
+    , device.time_zone_offset_seconds as device_time_zone_offset_seconds
+    , device.browser as device_browser
+    , device.browser_version as device_browser_version
+    , device.web_info.browser as device_web_info_browser
+    , device.web_info.browser_version as device_web_info_browser_version
+    , device.web_info.hostname as device_web_info_hostname
+    , geo.continent as geo_continent
+    , geo.country as geo_country
+    , geo.region as geo_region
+    , geo.city as geo_city
+    , geo.sub_continent as geo_sub_continent
+    , geo.metro as geo_metro
+    , app_info.id as app_info_id
+    , app_info.version as app_info_version
+    , app_info.install_store as app_info_install_store
+    , app_info.firebase_app_id as app_info_firebase_app_id
+    , app_info.install_source as app_info_install_source
+    , traffic_source.name as user_campaign
+    , traffic_source.medium as user_medium
+    , traffic_source.source as user_source
+    , stream_id
+    , platform
+    , struct(
         total_item_quantity
         , purchase_revenue_in_usd
         , purchase_revenue
@@ -104,8 +104,8 @@
         , tax_value
         , unique_items
         , transaction_id        
-    ) as ecommerce,
-    (select 
+    ) as ecommerce
+    , (select 
         array_agg(struct(
             unnested_items.item_id
             , unnested_items.item_name
@@ -135,27 +135,27 @@
             , unnested_items.creative_slot
             , unnested_items.item_params
         )) from unnest(items) as unnested_items 
-    ) items,
-    {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value', 'session_id') }},
-    {{ ga4.unnest_key('event_params', 'page_location') }},
-    {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value', 'session_number') }},
-    COALESCE(
+    ) items
+    , {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value', 'session_id') }}
+    , {{ ga4.unnest_key('event_params', 'page_location') }}
+    , {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value', 'session_number') }}
+    , COALESCE(
         (SELECT value.int_value FROM unnest(event_params) WHERE key = "session_engaged"),
         (CASE WHEN (SELECT value.string_value FROM unnest(event_params) WHERE key = "session_engaged") = "1" THEN 1 END)
-    ) as session_engaged,
-    {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }},
-    {{ ga4.unnest_key('event_params', 'page_title') }},
-    {{ ga4.unnest_key('event_params', 'page_referrer') }},
-    {{ ga4.unnest_key('event_params', 'source', 'lower_string_value', 'event_source') }},
-    {{ ga4.unnest_key('event_params', 'medium', 'lower_string_value', 'event_medium') }},
-    {{ ga4.unnest_key('event_params', 'campaign', 'lower_string_value', 'event_campaign') }},
-    {{ ga4.unnest_key('event_params', 'content', 'lower_string_value', 'event_content') }},
-    {{ ga4.unnest_key('event_params', 'term', 'lower_string_value', 'event_term') }},
-    CASE 
+    ) as session_engaged
+    , {{ ga4.unnest_key('event_params', 'engagement_time_msec', 'int_value') }}
+    , {{ ga4.unnest_key('event_params', 'page_title') }}
+    , {{ ga4.unnest_key('event_params', 'page_referrer') }}
+    , {{ ga4.unnest_key('event_params', 'source', 'lower_string_value', 'event_source') }}
+    , {{ ga4.unnest_key('event_params', 'medium', 'lower_string_value', 'event_medium') }}
+    , {{ ga4.unnest_key('event_params', 'campaign', 'lower_string_value', 'event_campaign') }}
+    , {{ ga4.unnest_key('event_params', 'content', 'lower_string_value', 'event_content') }}
+    , {{ ga4.unnest_key('event_params', 'term', 'lower_string_value', 'event_term') }}
+    , CASE 
         WHEN event_name = 'page_view' THEN 1
         ELSE 0
-    END AS is_page_view,
-    CASE 
+    END AS is_page_view
+    , CASE 
         WHEN event_name = 'purchase' THEN 1
         ELSE 0
     END AS is_purchase


### PR DESCRIPTION
## Description & motivation
In order to prevent Google changes to the `items` and `ecommerce` records breaking the package, this PR hard-codes the fields output by the `base_select` macro which will prevent changes from breaking and allow users to override the macro and incorporate changes without waiting on a package update.

Resolves #281 

## Checklist
- [y ] I have verified that these changes work locally
- [y ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [y ] I have run `dbt test` and `python -m pytest .` to validate existing tests
