### PR TITLE
Allow distinct source and target projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,12 +77,25 @@ This package assumes that you have an existing DBT project with a BigQuery profi
 ```
 vars:
   ga4:
-    project: "your_gcp_project"
-    dataset: "your_ga4_dataset"
+    source_project: "my_source_gcp_project" # Project that contains raw GA4 data
+    property_ids: [11111111] # Array of properties to process
     start_date: "YYYYMMDD" # Earliest date to load
     static_incremental_days: 3 # Number of days to scan and reprocess on each run
 ```
-See [Multi-Property Support](#multi-property-support) section for details on configuring multiple GA4 properties as a source.
+
+## Required Variables (Multi-Project Instance)
+
+When processing multiple properties at a time, the required variables change slightly. See [Multi-Property Support](#multi-property-support) section for details on configuring multiple GA4 properties as a source.
+
+```
+vars:
+  ga4:
+    source_project: "my_source_gcp_project" # Project that contains raw GA4 data
+    combined_dataset: "my_combined_data" # Dataset where multi-property data is cloned
+    property_ids: [11111111,2222222] # Array of properties to process
+    start_date: "YYYYMMDD" # Earliest date to load
+    static_incremental_days: 3 # Number of days to scan and reprocess on each run
+```
 
 ## Optional Variables
 

--- a/README.md
+++ b/README.md
@@ -308,14 +308,14 @@ Overriding the package's default channel mapping makes use of dbt's dispatch ove
 
 # Multi-Property Support
 
-Multiple GA4 properties are supported by listing out the project IDs in the `property_ids` variable. In this scenario, the `static_incremental_days` variable is required and the `dataset` variable will define the target dataset where source data will be copied.
+Multiple GA4 properties are supported by listing out the project IDs in the `property_ids` variable. In this scenario, the `static_incremental_days` variable is required and the `combined_dataset` variable will define the dataset (in your profile's target project) where source data will be copied.
 
 ```
 vars:
   ga4:
     property_ids: [11111111, 22222222, 33333333]
     static_incremental_days: 3
-    dataset: "my_combined_dataset"
+    combined_dataset: "my_combined_dataset"
 ```
 
 With these variables set, the `combine_property_data` macro will run as a pre-hook to `base_ga4_events` and clone shards to the target dataset.  The number of days' worth of data to clone during incremental runs will be based on the `static_incremental_days` variable. 

--- a/macros/combine_property_data.sql
+++ b/macros/combine_property_data.sql
@@ -18,19 +18,19 @@
     {% for property_id in var('property_ids') %}
         {%- set schema_name = "analytics_" + property_id|string -%}
             {# Copy intraday tables #}
-            {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_intraday_%', database=var('project')) -%}
+            {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_intraday_%', database=var('source_project')) -%}
             {% for relation in relations %}
                 {%- set relation_suffix = relation.identifier|replace('events_intraday_', '') -%}
                 {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
-                    CREATE OR REPLACE TABLE `{{target.project}}.{{var('combined_dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_intraday_{{relation_suffix}}`;
+                    CREATE OR REPLACE TABLE `{{target.project}}.{{var('combined_dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}` CLONE `{{var('source_project')}}.analytics_{{property_id}}.events_intraday_{{relation_suffix}}`;
                 {%- endif -%}
             {% endfor %}
             {# Copy daily tables and drop old intraday table #}
-            {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_%', exclude='events_intraday_%', database=var('project')) -%}
+            {%- set relations = dbt_utils.get_relations_by_pattern(schema_pattern=schema_name, table_pattern='events_%', exclude='events_intraday_%', database=var('source_project')) -%}
             {% for relation in relations %}
                 {%- set relation_suffix = relation.identifier|replace('events_', '') -%}
                 {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
-                    CREATE OR REPLACE TABLE `{{target.project}}.{{var('combined_dataset')}}.events_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_{{relation_suffix}}`;
+                    CREATE OR REPLACE TABLE `{{target.project}}.{{var('combined_dataset')}}.events_{{relation_suffix}}{{property_id}}` CLONE `{{var('source_project')}}.analytics_{{property_id}}.events_{{relation_suffix}}`;
                     DROP TABLE IF EXISTS `{{target.project}}.{{var('combined_dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}`;
                 {%- endif -%}
             {% endfor %}

--- a/macros/combine_property_data.sql
+++ b/macros/combine_property_data.sql
@@ -4,7 +4,7 @@
 
 {% macro default__combine_property_data() %}
 
-    create schema if not exists `{{var('project')}}.{{var('dataset')}}`;
+    create schema if not exists `{{target.project}}.{{var('combined_dataset')}}`;
 
     {# If incremental, then use static_incremental_days variable to find earliest shard to copy #}
     {% if not should_full_refresh() %}
@@ -22,7 +22,7 @@
             {% for relation in relations %}
                 {%- set relation_suffix = relation.identifier|replace('events_intraday_', '') -%}
                 {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
-                    CREATE OR REPLACE TABLE `{{var('project')}}.{{var('dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_intraday_{{relation_suffix}}`;
+                    CREATE OR REPLACE TABLE `{{target.project}}.{{var('combined_dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_intraday_{{relation_suffix}}`;
                 {%- endif -%}
             {% endfor %}
             {# Copy daily tables and drop old intraday table #}
@@ -30,8 +30,8 @@
             {% for relation in relations %}
                 {%- set relation_suffix = relation.identifier|replace('events_', '') -%}
                 {%- if relation_suffix|int >= earliest_shard_to_retrieve|int -%}
-                    CREATE OR REPLACE TABLE `{{var('project')}}.{{var('dataset')}}.events_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_{{relation_suffix}}`;
-                    DROP TABLE IF EXISTS `{{var('project')}}.{{var('dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}`;
+                    CREATE OR REPLACE TABLE `{{target.project}}.{{var('combined_dataset')}}.events_{{relation_suffix}}{{property_id}}` CLONE `{{var('project')}}.analytics_{{property_id}}.events_{{relation_suffix}}`;
+                    DROP TABLE IF EXISTS `{{target.project}}.{{var('combined_dataset')}}.events_intraday_{{relation_suffix}}{{property_id}}`;
                 {%- endif -%}
             {% endfor %}
     {% endfor %}

--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -5,7 +5,7 @@
 
 {{
     config(
-        pre_hook="{{ ga4.combine_property_data() }}" if var('property_ids', false) else "",
+        pre_hook="{{ ga4.combine_property_data() }}" if var('combined_dataset', false) else "",
         materialized = 'incremental',
         incremental_strategy = 'insert_overwrite',
         partition_by={

--- a/models/staging/src_ga4.yml
+++ b/models/staging/src_ga4.yml
@@ -3,7 +3,10 @@ version: 2
 sources:
   - name: ga4
     database: "{{var('source_project')}}" 
-    schema: "{{var('dataset')}}" 
+    schema: | # Source from combined property dataset if set, otherwise source from source property
+      {%- if  var('combined_dataset', false) != false -%} {{var('combined_dataset')}}
+      {%- else -%} "analytics_{{var('property_ids')[0]}}"
+      {%- endif -%}
     tables:
       - name: events
         identifier: events_* # Scan across all sharded event tables. Use the 'start_date' variable to limit this scan

--- a/models/staging/src_ga4.yml
+++ b/models/staging/src_ga4.yml
@@ -2,7 +2,7 @@ version: 2
 
 sources:
   - name: ga4
-    database: "{{var('project')}}" 
+    database: "{{var('source_project')}}" 
     schema: "{{var('dataset')}}" 
     tables:
       - name: events

--- a/models/staging/src_ga4.yml
+++ b/models/staging/src_ga4.yml
@@ -2,8 +2,11 @@ version: 2
 
 sources:
   - name: ga4
-    database: "{{var('source_project')}}" 
-    schema: | # Source from combined property dataset if set, otherwise source from source property
+    database: | # Source from target.project if multi-property, otherwise source from source_project
+      {%- if  var('combined_dataset', false) != false -%} {{target.project}}
+      {%- else -%} {{var('source_project')}}
+      {%- endif -%}
+    schema: | # Source from combined property dataset if set, otherwise source from original GA4 property
       {%- if  var('combined_dataset', false) != false -%} {{var('combined_dataset')}}
       {%- else -%} analytics_{{var('property_ids')[0]}}
       {%- endif -%}

--- a/models/staging/src_ga4.yml
+++ b/models/staging/src_ga4.yml
@@ -5,7 +5,7 @@ sources:
     database: "{{var('source_project')}}" 
     schema: | # Source from combined property dataset if set, otherwise source from source property
       {%- if  var('combined_dataset', false) != false -%} {{var('combined_dataset')}}
-      {%- else -%} "analytics_{{var('property_ids')[0]}}"
+      {%- else -%} analytics_{{var('property_ids')[0]}}
       {%- endif -%}
     tables:
       - name: events


### PR DESCRIPTION
## Description & motivation
This update allows users to set distinct source and target projects. This helps in scenarios where the dbt user is not able to write to the source project. The target project is pulled from the current profile (`target.project`).

!!Certain variables have been renamed which introduce breaking changes!!

`dataset` and `project` no longer exist as the `target.dataset` and `target.project` will be used.
New variable: `source_project` is now required to indicate the source of the GA4 data
New variable: `combined_dataset` is required when sourcing from multiple properties. This specifies where to copy the cloned data. The `target.project` will be used to clone data.
`property_ids` variable is an array and is used to indicate which property IDs to source from. Can be used for single or multi-property instances (ex: [1111111] for 1 property or [1111111,2222222] for 2, etc)

## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
