### PR TITLE
Update default channel grouping label to Direct

### DIFF
--- a/models/staging/stg_ga4__sessions_traffic_sources_last_non_direct_daily.sql
+++ b/models/staging/stg_ga4__sessions_traffic_sources_last_non_direct_daily.sql
@@ -66,7 +66,7 @@ with last_non_direct_session_partition_key as (
     ,coalesce(last_non_direct_source.session_campaign, '(none)') as last_non_direct_campaign
     ,coalesce(last_non_direct_source.session_content, '(none)') as last_non_direct_content
     ,coalesce(last_non_direct_source.session_term, '(none)') as last_non_direct_term
-    ,coalesce(last_non_direct_source.session_default_channel_grouping, '(none)') as last_non_direct_default_channel_grouping
+    ,coalesce(last_non_direct_source.session_default_channel_grouping, 'Direct') as last_non_direct_default_channel_grouping
   from last_non_direct_session_partition_key
   left join {{ref('stg_ga4__sessions_traffic_sources_daily')}} last_non_direct_source on
     last_non_direct_session_partition_key.session_partition_key_last_non_direct = last_non_direct_source.session_partition_key


### PR DESCRIPTION
## Description & motivation
Fixes #300 

The default session grouping for the last-non-direct model was mistaken set to `(none)` instead of `Direct` when the source was direct. This was likely a copy/paste error. 

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
