### PR TITLE
Fix to filter based on dates equal to or later than the start_date

### DIFF
--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -21,7 +21,7 @@ with source as (
     select
         {{ ga4.base_select_source() }}
     from {{ source('ga4', 'events') }}
-    where cast(replace(_table_suffix, 'intraday_', '') as int64) >= {{var('start_date')}}
+    where cast(left(replace(_table_suffix, 'intraday_', ''), 8) as int64) >= {{var('start_date')}}
     {% if is_incremental() %}
         and parse_date('%Y%m%d', left(replace(_table_suffix, 'intraday_', ''), 8)) in ({{ partitions_to_replace | join(',') }})
     {% endif %}

--- a/models/staging/base/base_ga4__events.sql
+++ b/models/staging/base/base_ga4__events.sql
@@ -18,16 +18,16 @@
 }}
 
 with source as (
-    select 
+    select
         {{ ga4.base_select_source() }}
-        from {{ source('ga4', 'events') }}
-        where cast( replace(_table_suffix, 'intraday_', '') as int64) >= {{var('start_date')}}
+    from {{ source('ga4', 'events') }}
+    where cast(replace(_table_suffix, 'intraday_', '') as int64) >= {{var('start_date')}}
     {% if is_incremental() %}
-        and parse_date('%Y%m%d', left( replace(_table_suffix, 'intraday_', ''), 8)) in ({{ partitions_to_replace | join(',') }})
+        and parse_date('%Y%m%d', left(replace(_table_suffix, 'intraday_', ''), 8)) in ({{ partitions_to_replace | join(',') }})
     {% endif %}
 ),
 renamed as (
-    select 
+    select
         {{ ga4.base_select_renamed() }}
     from source
 )


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

In the original code `cast(replace(_table_suffix, 'intraday_', '') as int64)`, larger values than the start_date were being retrieved, resulting in unsuccessful filtering.

```sql
select distinct
    _table_suffix
    , cast(replace(_table_suffix, 'intraday_', '') as int64) as original
    , cast(left(replace(_table_suffix, 'intraday_', ''), 8) as int64) as correct
from `{{ target.project }}`.`{{ var('combined_dataset') }}`.`events_*`
limit 1
```

- original: `{{ YYYYMMDD }}{{ property_id }}`
- correct: `{{ YYYYMMDD }}`

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
