### PR TITLE
Fix uniqueness test for fct_ga4__pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Features include:
 | dim_ga4__client_keys | Dimension table for user devices as indicated by client_keys. Contains attributes such as first and last page viewed.| 
 | dim_ga4__sessions | Dimension table for sessions which contains useful attributes such as geography, device information, and acquisition data. Can be expensive to run on large installs (see `dim_ga4__sessions_daily`) |
 | dim_ga4__sessions_daily | Query-optimized session dimension table that is incremental and partitioned on date. Assumes that each partition is contained within a single day |
-| fct_ga4__pages | Fact table for pages which aggregates common page metrics by page_location and date. |
+| fct_ga4__pages | Fact table for pages which aggregates common page metrics by date, stream_id and page_location. |
 | fct_ga4__sessions_daily | Fact table for session metrics, partitioned by date. A single session may span multiple rows given that sessions can span multiple days.  |
 | fct_ga4__sessions | Fact table that aggregates session metrics across days. This table is not partitioned, so be mindful of performance/cost when querying. |
 

--- a/models/marts/core/fct_ga4__pages.yml
+++ b/models/marts/core/fct_ga4__pages.yml
@@ -2,10 +2,10 @@ version: 2
 
 models:
   - name: fct_ga4__pages
-    description: Incremental model with page metrics such as visits, users, new_users, entrances and exits as well as configurable conversion counts grouped by page_location. 
+    description: Incremental model with page metrics such as visits, users, new_users, entrances and exits as well as configurable conversion counts grouped by stream_id and page_location.
     tests:
       - unique:
-          column_name: "(page_location || event_date_dt)"
+          column_name: "(event_date_dt || stream_id || page_location)"
     columns:
       - name: total_engagement_time_msec
         description: The total engagement time for that page_location.


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Fix uniqueness test for fct_ga4__pages.

Multiple records can have the same event_date_dt and page_location.
Adding stream_id as a condition makes them unique.

> Data stream: Lives within a property, and is the source of data from an app or website. The best practice is to use a maximum of 3 data streams per property: 1 single web data stream to measure the web user journey and 1 app data stream each for iOS and Android.
>
> [[GA4] Google Analytics account structure - Analytics Help](https://support.google.com/analytics/answer/9679158?hl=en)

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
