### PR TITLE
fix cpc classification and add test

### DIFF
--- a/models/staging/stg_ga4__events.sql
+++ b/models/staging/stg_ga4__events.sql
@@ -38,10 +38,12 @@ detect_gclid as (
         end as event_source,
         case
             when (page_location like '%gclid%' and event_medium is null) then "cpc"
+            when (page_location like '%gclid%' and event_medium = 'organic') then "cpc"
             else event_medium
         end as event_medium,
         case
             when (page_location like '%gclid%' and event_campaign is null) then "(cpc)"
+            when (page_location like '%gclid%' and event_campaign = 'organic') then "(cpc)"
             else event_campaign
         end as event_campaign
     from include_event_key

--- a/tests/page_location_with_gclid_is_cpc.sql
+++ b/tests/page_location_with_gclid_is_cpc.sql
@@ -1,12 +1,6 @@
 -- Google has changed the combination of parameters that are used to identify a CPC source in the past.
 -- In order to detect new changes, this test checks that a page_location with a gclid is classified as cpc.
--- The purpose of this test is to detect changes in the source classification of CPC traffic.
--- As a result, it defaults to testing only the last static_incremental_days worth of tests.
 
-{% set partitions_to_replace = ['current_date'] %}
-{% for i in range(var('static_incremental_days', 1)) %}
-    {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
-{% endfor %}
 {{config(
     severity = 'warn'
 )}}
@@ -17,6 +11,5 @@ from {{ref('stg_ga4__events')}}
 where page_location like '%gclid%'
     and event_source != 'google'
     and event_medium != 'cpc'
-    and event_date_dt in ({{ partitions_to_replace | join(',') }})
 having sources > 0
     or mediums > 0

--- a/tests/page_location_with_gclid_is_cpc.sql
+++ b/tests/page_location_with_gclid_is_cpc.sql
@@ -1,0 +1,22 @@
+-- Google has changed the combination of parameters that are used to identify a CPC source in the past.
+-- In order to detect new changes, this test checks that a page_location with a gclid is classified as cpc.
+-- The purpose of this test is to detect changes in the source classification of CPC traffic.
+-- As a result, it defaults to testing only the last static_incremental_days worth of tests.
+
+{% set partitions_to_replace = ['current_date'] %}
+{% for i in range(var('static_incremental_days', 1)) %}
+    {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+{% endfor %}
+{{config(
+    severity = 'warn'
+)}}
+select
+    count(event_source) as sources
+    , count(event_medium) as mediums
+from {{ref('stg_ga4__events')}}
+where page_location like '%gclid%'
+    and event_source != 'google'
+    and event_medium != 'cpc'
+    and event_date_dt in ({{ partitions_to_replace | join(',') }})
+having sources > 0
+    or mediums > 0

--- a/tests/page_location_with_gclid_is_cpc.sql
+++ b/tests/page_location_with_gclid_is_cpc.sql
@@ -8,7 +8,7 @@ select
     count(event_source) as sources
     , count(event_medium) as mediums
 from {{ref('stg_ga4__events')}}
-where page_location like '%gclid%'
+where original_page_location like '%gclid%'
     and event_source != 'google'
     and event_medium != 'cpc'
 having sources > 0


### PR DESCRIPTION
## Description & motivation
Resolves #302

Google has started sometimes setting source and medium values to google / organic when a visitor clicks an ad.

This breaks the code that we use to fix google / cpc source/medium values that are mis-attributed to google / organic in the stg_ga4__events file.

This PR fixes that issue and adds a test to detect when it might happens again.

## Checklist
- [ y] I have verified that these changes work locally
- [ n/a] I have updated the README.md (if applicable)
- [ y] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
