### PR TITLE
Update stg_ga4__events.sql to consider campaign name (organic)

### DIFF
--- a/models/staging/stg_ga4__events.sql
+++ b/models/staging/stg_ga4__events.sql
@@ -44,6 +44,7 @@ detect_gclid as (
         case
             when (page_location like '%gclid%' and event_campaign is null) then "(cpc)"
             when (page_location like '%gclid%' and event_campaign = 'organic') then "(cpc)"
+            when (page_location like '%gclid%' and event_campaign = '(organic)') then "(cpc)"
             else event_campaign
         end as event_campaign
     from include_event_key


### PR DESCRIPTION
## Description & motivation
<!---
Recent update #306 for attribution of gclid-related source/medium/campaign assumes campaign name is "organic" and does not consider when campaign name is within parenthesis: "(organic)"

This update adds logic to the case statement for redefining gclid traffic when campaign name is "(organic)" to be changed to have campaign name "(cpc)".
-->

## Checklist
- [y ] I have verified that these changes work locally
- [na ] I have updated the README.md (if applicable)
- [na ] I have added tests & descriptions to my models (and macros if applicable)
- [y ] I have run `dbt test` and `python -m pytest .` to validate existing tests
