### PR TITLE
User Export

### DIFF
--- a/macros/base_select.sql
+++ b/macros/base_select.sql
@@ -160,3 +160,48 @@
         ELSE 0
     END AS is_purchase
 {% endmacro %}
+
+{% macro base_select_usr_source() %}
+    {{ return(adapter.dispatch('base_select_usr_source', 'ga4')()) }}
+{% endmacro %}
+
+{% macro default__base_select_usr_source() %}
+    , user_info.last_active_timestamp_micros 
+    , user_info.user_first_touch_timestamp_micros 
+    , user_info.first_purchase_date 
+    , device.operating_system 
+    , device.category 
+    , device.mobile_brand_name 
+    , device.mobile_model_name 
+    , device.unified_screen_name 
+    , geo.city 
+    , geo.country 
+    , geo.continent 
+    , geo.region 
+    , user_ltv.revenue_in_usd 
+    , user_ltv.sessions 
+    , user_ltv.engagement_time_millis 
+    , user_ltv.purchases 
+    , user_ltv.engaged_sessions 
+    , user_ltv.session_duration_micros 
+    , predictions.in_app_purchase_score_7d 
+    , predictions.purchase_score_7d 
+    , predictions.churn_score_7d 
+    , predictions.revenue_28d_in_usd 
+    , privacy_info.is_limited_ad_tracking 
+    , privacy_info.is_ads_personalization_allowed 
+    , occurrence_date 
+    , last_updated_date
+    {% for up in var('user_properties', []) %} -- don't have sample data; need to verify
+        , (select value.string_value from unnest(user_properties) where key = '{{up}}') as {{up | lower | replace(" ", "_")}}_string_value 
+        , (select value.set_timestamp_micros from unnest(user_properties) where key = '{{up}}') as {{up | lower | replace(" ", "_")}}_set_timestamp_micros
+        , (select value.user_property_name from unnest(user_properties) where key = '{{up}}') as {{up | lower | replace(" ", "_")}}_user_property_name 
+    {% endfor %}
+    {% for aud in var('audiences', []) %} -- this should be good, though
+        , (select id from unnest(audiences) where name = '{{aud}}') as {{aud | lower | replace(" ", "_")}}_id
+        , (select name from unnest(audiences) where name = '{{aud}}') as {{aud | lower | replace(" ", "_")}}_name 
+        , (select membership_start_timestamp_micros from unnest(audiences) where name = '{{aud}}') as {{aud | lower | replace(" ", "_")}}_membership_start_timestamp_micros
+        , (select membership_expiry_timestamp_micros from unnest(audiences) where name = '{{aud}}') as {{aud | lower | replace(" ", "_")}}_membership_expiry_timestamp_micros
+        , (select npa from unnest(audiences) where name = '{{aud}}') as {{aud | replace(" ", "_")}}_npa
+    {% endfor %}
+{% endmacro %}

--- a/models/staging/base/base_ga4__pseudonymous_users.sql
+++ b/models/staging/base/base_ga4__pseudonymous_users.sql
@@ -1,0 +1,30 @@
+{% set partitions_to_replace = ['current_date'] %}
+{% for i in range(var('static_incremental_days')) %}
+    {% set partitions_to_replace = partitions_to_replace.append('date_sub(current_date, interval ' + (i+1)|string + ' day)') %}
+{% endfor %}
+
+{{
+    config(
+ -- todo multi-site
+        materialized = 'incremental',
+        incremental_strategy = 'insert_overwrite',
+        partition_by={
+            "field": "occurence_date",
+            "data_type": "date",
+        },
+        partitions = partitions_to_replace,
+    )
+}}
+
+with source as (
+    select
+        pseudo_user_id
+        , stream_id 
+        {{ ga4.base_select_usr_source() }}
+    from {{ source('ga4', 'pseudonymous_users') }}
+    {% if is_incremental() %}
+        where parse_date('%Y%m%d', left(replace(_table_suffix, 'intraday_', ''), 8)) in ({{ partitions_to_replace | join(',') }})
+    {% endif %}
+)
+
+select * from source

--- a/models/staging/src_ga4.yml
+++ b/models/staging/src_ga4.yml
@@ -14,3 +14,9 @@ sources:
       - name: events
         identifier: events_* # Scan across all sharded event tables. Use the 'start_date' variable to limit this scan
         description: Main events table exported by GA4. Sharded by date. 
+      - name: pseudonymous_users
+        identifier: pseudonymous_users_* 
+        description: Daily sharded pseudonymous_users (client_id) table exported by GA4
+      - name: users
+        identifier: users_* 
+        description: Daily sharded users (user_id) table exported by GA4


### PR DESCRIPTION
## Description & motivation
Work-in-progress resolving #285.

The goal of this PR is to support the `pseudonymous_user_id` and `user_id` tables.

My initial thought is that we should keep both the package's current user tables and new ones derived from the new user export options in GA4. The reason for this is to support both old and new installations.

README modifications are not done, but I expect we will want to add a new section on disabling user models that explains the differences between our various models and how to use them.

What defaults should we have for `+enable` on these tables?

This PR supports `audiences` fields from the export. While working with a test site that has implemented audiences, the data doesn't seem to be very useful unless its ID field joins with Google Ads audience exports. Despite this, I think we should leave this in because it needs to be enabled by a variable.

The `user_properties` fields were done without sample data. Naming and logic will likely need to be updated.

Multi-site is not currently supported.

We also might want to move the logic in `base_ga4___*` models to `stg_ga4__*` models.

I also need to review package naming conventions to ensure data, like geo data, is consistent with elsewhere in the package.

To-do:
- data marts
- review package naming conventions to ensure consistency
- `user_property` logic
- readme
- multi-site

Here are the [docs for the source tables](https://support.google.com/analytics/answer/12769371?hl=en&ref_topic=9359001&sjid=5665659258369477-NC).

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
