### PR TITLE
feature: add property_id

### DIFF
--- a/macros/base_select.sql
+++ b/macros/base_select.sql
@@ -35,7 +35,7 @@
     , ecommerce.unique_items
     , ecommerce.transaction_id
     , items
-    , {%- if  var('combined_dataset', false) != false %} cast(left(regexp_replace(_table_suffix, r'^\d{8}', ''), 100) as int64)
+    , {%- if  var('combined_dataset', false) != false %} cast(left(regexp_replace(_table_suffix, r'^(intraday_)?\d{8}', ''), 100) as int64)
         {%- else %} {{ var('property_ids')[0] }}
         {%- endif %} as property_id
 {% endmacro %}

--- a/macros/base_select.sql
+++ b/macros/base_select.sql
@@ -35,6 +35,9 @@
     , ecommerce.unique_items
     , ecommerce.transaction_id
     , items
+    , {%- if  var('combined_dataset', false) != false %} cast(left(regexp_replace(_table_suffix, r'^\d{8}', ''), 100) as int64)
+        {%- else %} {{ var('property_ids')[0] }}
+        {%- endif %} as property_id
 {% endmacro %}
 
 {% macro base_select_renamed() %}
@@ -136,6 +139,7 @@
             , unnested_items.item_params
         )) from unnest(items) as unnested_items 
     ) items
+    , property_id
     , {{ ga4.unnest_key('event_params', 'ga_session_id', 'int_value', 'session_id') }}
     , {{ ga4.unnest_key('event_params', 'page_location') }}
     , {{ ga4.unnest_key('event_params', 'ga_session_number',  'int_value', 'session_number') }}


### PR DESCRIPTION
## Description & motivation
This PR adds a new `property_id` column to the `base_ga4__events` model which is derived from either the name of the imported dataset or the `property_ids` dbt variable (depending on whether this is a multi-property or single-property project).

Note that the default behavior of dbt is to ignore new columns during incremental runs. This behavior can be overridden with the `on_schema_change` configuration https://docs.getdbt.com/docs/build/incremental-models#what-if-the-columns-of-my-incremental-model-change

## Checklist
- [x] I have verified that these changes work locally
- [na] I have updated the README.md (if applicable)
- [na] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
