### PR TITLE
Fix invalid generated column names in conversion events

### DIFF
--- a/macros/valid_column_name.sql
+++ b/macros/valid_column_name.sql
@@ -1,0 +1,14 @@
+{% macro valid_column_name(column_name) %}
+  {% set re = modules.re %}
+  {% set pattern = '[^a-zA-Z0-9_]' %}
+  {# a column name can't contain a non alphanumeric or _ character #}
+  {% set cleaned_name = re.sub(pattern, '_', column_name|string) %}
+
+  {% if re.match('^\d', cleaned_name) %}
+    {# a column name can't start by a number #}
+    {{ return("_" ~ cleaned_name) }}
+  {% else %}
+    {{ return(cleaned_name) }}
+  {% endif %}
+
+{% endmacro %}

--- a/macros/valid_column_name.sql
+++ b/macros/valid_column_name.sql
@@ -4,7 +4,7 @@
   {# a column name can't contain a non alphanumeric or _ character #}
   {% set cleaned_name = re.sub(pattern, '_', column_name|string) %}
 
-  {% if re.match('^\d', cleaned_name) %}
+  {% if re.match('^\\d', cleaned_name) %}
     {# a column name can't start by a number #}
     {{ return("_" ~ cleaned_name) }}
   {% else %}

--- a/models/marts/core/fct_ga4__client_keys.sql
+++ b/models/marts/core/fct_ga4__client_keys.sql
@@ -10,7 +10,8 @@ select
     count(distinct session_key)  as count_sessions
     {% if var('conversion_events', false) %}
         {% for ce in var('conversion_events',[]) %}
-            , sum(count_{{ce}}) as count_{{ce}}
+          {% set clean_ce = ga4.valid_column_name(ce) %}
+            , sum(count_{{clean_ce}}) as count_{{clean_ce}}
         {% endfor %}
     {% endif %}
 from {{ref('fct_ga4__sessions')}}

--- a/models/marts/core/fct_ga4__sessions.sql
+++ b/models/marts/core/fct_ga4__sessions.sql
@@ -14,7 +14,8 @@ select
     min(session_number) as session_number
     {% if var('conversion_events', false) %}
         {% for ce in var('conversion_events',[]) %}
-            , sum({{ce}}_count) as count_{{ce}}
+          {% set clean_ce = ga4.valid_column_name(ce) %}
+            , sum({{clean_ce}}_count) as count_{{clean_ce}}
         {% endfor %}
     {% endif %}
 from {{ref('fct_ga4__sessions_daily')}}

--- a/models/marts/core/fct_ga4__user_ids.sql
+++ b/models/marts/core/fct_ga4__user_ids.sql
@@ -24,7 +24,8 @@ select
     sum(count_sessions) as count_sessions
     {% if var('conversion_events', false) %}
         {% for ce in var('conversion_events',[]) %}
-            , sum(count_{{ce}}) as count_{{ce}}
+          {% set clean_ce = ga4.valid_column_name(ce) %}
+            , sum(count_{{clean_ce}}) as count_{{clean_ce}}
         {% endfor %}
     {% endif %}
 from user_id_mapped

--- a/models/staging/stg_ga4__page_conversions.sql
+++ b/models/staging/stg_ga4__page_conversions.sql
@@ -5,7 +5,7 @@
 select 
     page_key
     {% for ce in var('conversion_events',[]) %}
-    , countif(event_name = '{{ce}}') as {{ce}}_count
+    , countif(event_name = '{{ce}}') as {{ga4.valid_column_name(ce)}}_count
     {% endfor %}
 from {{ref('stg_ga4__events')}}
 group by 1

--- a/models/staging/stg_ga4__session_conversions_daily.sql
+++ b/models/staging/stg_ga4__session_conversions_daily.sql
@@ -25,7 +25,7 @@ with event_counts as (
         session_partition_key,
         min(event_date_dt) as session_partition_date -- The date of this session partition
         {% for ce in var('conversion_events',[]) %}
-        , countif(event_name = '{{ce}}') as {{ce}}_count
+        , countif(event_name = '{{ce}}') as {{ga4.valid_column_name(ce)}}_count
         {% endfor %}
     from {{ref('stg_ga4__events')}}
     where 1=1

--- a/unit_tests/test_stg_ga4__page_conversions.py
+++ b/unit_tests/test_stg_ga4__page_conversions.py
@@ -9,9 +9,9 @@ page_view,B
 """.lstrip()
 
 mock_stg_ga4__nonstandard_events_csv = """event_name,page_key
-page-view,A
-page-view,A
-page-view,B
+my-page-view,A
+my-page-view,A
+my-page-view,B
 """.lstrip()
 
 expected_csv = """page_key,page_view_count
@@ -29,6 +29,14 @@ class TestPageConversions:
         return {
             "name": "ga4"
         }
+    
+    # everything that goes in the "macros"
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "valid_column_name.sql": read_file('../macros/valid_column_name.sql'),
+        }
+
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -58,6 +66,13 @@ class TestPageConversionsNonStandardEventName:
             "stg_ga4__events.csv": mock_stg_ga4__nonstandard_events_csv,
             "expected.csv": expected_csv,
         }
+    
+    # everything that goes in the "macros"
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "valid_column_name.sql": read_file('../macros/valid_column_name.sql'),
+        }
 
     # everything that goes in the "models" directory (= SQL)
     @pytest.fixture(scope="class")
@@ -67,6 +82,6 @@ class TestPageConversionsNonStandardEventName:
         }
 
     def test_mock_run_and_check(self, project):
-        run_dbt(["build", "--vars", "conversion_events: ['page-view']"])
+        run_dbt(["build", "--vars", "conversion_events: ['my-page-view']"])
         # breakpoint()
         check_relations_equal(project.adapter, ["actual", "expected"])

--- a/unit_tests/test_stg_ga4__page_conversions.py
+++ b/unit_tests/test_stg_ga4__page_conversions.py
@@ -9,9 +9,9 @@ page_view,B
 """.lstrip()
 
 mock_stg_ga4__nonstandard_events_csv = """event_name,page_key
-my-page-view,A
-my-page-view,A
-my-page-view,B
+page-view,A
+page-view,A
+page-view,B
 """.lstrip()
 
 expected_csv = """page_key,page_view_count
@@ -26,15 +26,13 @@ class TestPageConversions:
     # Update project name to ga4 so we can call macros with ga4.macro_name
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {
-            "name": "ga4"
-        }
-    
+        return {"name": "ga4"}
+
     # everything that goes in the "macros"
     @pytest.fixture(scope="class")
     def macros(self):
         return {
-            "valid_column_name.sql": read_file('../macros/valid_column_name.sql'),
+            "valid_column_name.sql": read_file("../macros/valid_column_name.sql"),
         }
 
     # everything that goes in the "seeds" directory (= CSV format)
@@ -66,12 +64,12 @@ class TestPageConversionsNonStandardEventName:
             "stg_ga4__events.csv": mock_stg_ga4__nonstandard_events_csv,
             "expected.csv": expected_csv,
         }
-    
+
     # everything that goes in the "macros"
     @pytest.fixture(scope="class")
     def macros(self):
         return {
-            "valid_column_name.sql": read_file('../macros/valid_column_name.sql'),
+            "valid_column_name.sql": read_file("../macros/valid_column_name.sql"),
         }
 
     # everything that goes in the "models" directory (= SQL)
@@ -82,6 +80,6 @@ class TestPageConversionsNonStandardEventName:
         }
 
     def test_mock_run_and_check(self, project):
-        run_dbt(["build", "--vars", "conversion_events: ['my-page-view']"])
+        run_dbt(["build", "--vars", "conversion_events: ['page-view']"])
         # breakpoint()
         check_relations_equal(project.adapter, ["actual", "expected"])

--- a/unit_tests/test_stg_ga4__page_conversions.py
+++ b/unit_tests/test_stg_ga4__page_conversions.py
@@ -23,6 +23,12 @@ actual = read_file("../models/staging/stg_ga4__page_conversions.sql")
 
 
 class TestPageConversions:
+    # Update project name to ga4 so we can call macros with ga4.macro_name
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "ga4"
+        }
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
     def seeds(self):

--- a/unit_tests/test_stg_ga4__page_conversions.py
+++ b/unit_tests/test_stg_ga4__page_conversions.py
@@ -1,5 +1,5 @@
 import pytest
-from dbt.tests.util import read_file,check_relations_equal,run_dbt
+from dbt.tests.util import check_relations_equal, read_file, run_dbt
 
 # Define mocks via CSV (seeds) or SQL (models)
 mock_stg_ga4__events_csv = """event_name,page_key
@@ -8,14 +8,21 @@ page_view,A
 page_view,B
 """.lstrip()
 
+mock_stg_ga4__nonstandard_events_csv = """event_name,page_key
+page-view,A
+page-view,A
+page-view,B
+""".lstrip()
+
 expected_csv = """page_key,page_view_count
 A,2
 B,1
 """.lstrip()
 
-actual = read_file('../models/staging/stg_ga4__page_conversions.sql')
+actual = read_file("../models/staging/stg_ga4__page_conversions.sql")
 
-class TestPageConversions():
+
+class TestPageConversions:
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -30,8 +37,30 @@ class TestPageConversions():
         return {
             "actual.sql": actual,
         }
-    
+
     def test_mock_run_and_check(self, project):
         run_dbt(["build", "--vars", "conversion_events: ['page_view']"])
-        #breakpoint()
+        # breakpoint()
+        check_relations_equal(project.adapter, ["actual", "expected"])
+
+
+class TestPageConversionsNonStandardEventName:
+    # everything that goes in the "seeds" directory (= CSV format)
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "stg_ga4__events.csv": mock_stg_ga4__nonstandard_events_csv,
+            "expected.csv": expected_csv,
+        }
+
+    # everything that goes in the "models" directory (= SQL)
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "actual.sql": actual,
+        }
+
+    def test_mock_run_and_check(self, project):
+        run_dbt(["build", "--vars", "conversion_events: ['page-view']"])
+        # breakpoint()
         check_relations_equal(project.adapter, ["actual", "expected"])

--- a/unit_tests/test_stg_ga4__session_conversions_daily.py
+++ b/unit_tests/test_stg_ga4__session_conversions_daily.py
@@ -31,6 +31,12 @@ actual = read_file("../models/staging/stg_ga4__session_conversions_daily.sql")
 
 
 class TestUsersFirstLastEvents:
+    # Update project name to ga4 so we can call macros with ga4.macro_name
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {
+            "name": "ga4"
+        }
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
     def seeds(self):

--- a/unit_tests/test_stg_ga4__session_conversions_daily.py
+++ b/unit_tests/test_stg_ga4__session_conversions_daily.py
@@ -44,6 +44,14 @@ class TestUsersFirstLastEvents:
             "stg_ga4__events.csv": mock_stg_ga4__events_csv,
             "expected.csv": expected_csv,
         }
+    
+    # everything that goes in the "macros"
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "valid_column_name.sql": read_file('../macros/valid_column_name.sql'),
+        }
+
 
     # everything that goes in the "models" directory (= SQL)
     @pytest.fixture(scope="class")
@@ -66,6 +74,14 @@ class TestUsersNonStandardEventName:
             "stg_ga4__events.csv": mock_stg_ga4__nonstandard_events_csv,
             "expected.csv": expected_csv,
         }
+    
+    # everything that goes in the "macros"
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "valid_column_name.sql": read_file('../macros/valid_column_name.sql'),
+        }
+
 
     # everything that goes in the "models" directory (= SQL)
     @pytest.fixture(scope="class")

--- a/unit_tests/test_stg_ga4__session_conversions_daily.py
+++ b/unit_tests/test_stg_ga4__session_conversions_daily.py
@@ -34,9 +34,8 @@ class TestUsersFirstLastEvents:
     # Update project name to ga4 so we can call macros with ga4.macro_name
     @pytest.fixture(scope="class")
     def project_config_update(self):
-        return {
-            "name": "ga4"
-        }
+        return {"name": "ga4", "vars": {"static_incremental_days": 3}}
+
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -44,14 +43,13 @@ class TestUsersFirstLastEvents:
             "stg_ga4__events.csv": mock_stg_ga4__events_csv,
             "expected.csv": expected_csv,
         }
-    
+
     # everything that goes in the "macros"
     @pytest.fixture(scope="class")
     def macros(self):
         return {
-            "valid_column_name.sql": read_file('../macros/valid_column_name.sql'),
+            "valid_column_name.sql": read_file("../macros/valid_column_name.sql"),
         }
-
 
     # everything that goes in the "models" directory (= SQL)
     @pytest.fixture(scope="class")
@@ -74,14 +72,13 @@ class TestUsersNonStandardEventName:
             "stg_ga4__events.csv": mock_stg_ga4__nonstandard_events_csv,
             "expected.csv": expected_csv,
         }
-    
+
     # everything that goes in the "macros"
     @pytest.fixture(scope="class")
     def macros(self):
         return {
-            "valid_column_name.sql": read_file('../macros/valid_column_name.sql'),
+            "valid_column_name.sql": read_file("../macros/valid_column_name.sql"),
         }
-
 
     # everything that goes in the "models" directory (= SQL)
     @pytest.fixture(scope="class")

--- a/unit_tests/test_stg_ga4__session_conversions_daily.py
+++ b/unit_tests/test_stg_ga4__session_conversions_daily.py
@@ -1,5 +1,5 @@
 import pytest
-from dbt.tests.util import read_file,check_relations_equal,run_dbt
+from dbt.tests.util import check_relations_equal, read_file, run_dbt
 
 # Define mocks via CSV (seeds) or SQL (models)
 mock_stg_ga4__events_csv = """session_key,session_partition_key,event_name,event_date_dt
@@ -11,6 +11,15 @@ C,C2022-01-01,some_other_event,2022-01-01
 A,A2022-01-02,my_conversion,2022-01-02
 """.lstrip()
 
+mock_stg_ga4__nonstandard_events_csv = """session_key,session_partition_key,event_name,event_date_dt
+A,A2022-01-01,page_view,2022-01-01
+A,A2022-01-01,my-conversion,2022-01-01
+A,A2022-01-01,my-conversion,2022-01-01
+B,B2022-01-01,my-conversion,2022-01-01
+C,C2022-01-01,some_other_event,2022-01-01
+A,A2022-01-02,my-conversion,2022-01-02
+""".lstrip()
+
 expected_csv = """session_key,session_partition_key,session_partition_date,my_conversion_count
 A,A2022-01-01,2022-01-01,2
 B,B2022-01-01,2022-01-01,1
@@ -18,9 +27,10 @@ C,C2022-01-01,2022-01-01,0
 A,A2022-01-02,2022-01-02,1
 """.lstrip()
 
-actual = read_file('../models/staging/stg_ga4__session_conversions_daily.sql')
+actual = read_file("../models/staging/stg_ga4__session_conversions_daily.sql")
 
-class TestUsersFirstLastEvents():
+
+class TestUsersFirstLastEvents:
     # everything that goes in the "seeds" directory (= CSV format)
     @pytest.fixture(scope="class")
     def seeds(self):
@@ -35,8 +45,30 @@ class TestUsersFirstLastEvents():
         return {
             "actual.sql": actual,
         }
-    
+
     def test_mock_run_and_check(self, project):
         run_dbt(["build", "--vars", "conversion_events: ['my_conversion']"])
-        #breakpoint()
+        # breakpoint()
+        check_relations_equal(project.adapter, ["actual", "expected"])
+
+
+class TestUsersNonStandardEventName:
+    # everything that goes in the "seeds" directory (= CSV format)
+    @pytest.fixture(scope="class")
+    def seeds(self):
+        return {
+            "stg_ga4__events.csv": mock_stg_ga4__nonstandard_events_csv,
+            "expected.csv": expected_csv,
+        }
+
+    # everything that goes in the "models" directory (= SQL)
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "actual.sql": actual,
+        }
+
+    def test_mock_run_and_check(self, project):
+        run_dbt(["build", "--vars", "conversion_events: ['my-conversion']"])
+        # breakpoint()
         check_relations_equal(project.adapter, ["actual", "expected"])


### PR DESCRIPTION
## Description & motivation

I encountered an issue with non standard event names that I wanted to use as conversion events.
Stuff like `50%_completion` or `condition-click`.
I can't change their names in GA4, so I opened this PR to propose a way to create clean column names when they are used to generate conversion events related models.
Currently, using the `conversion_events` variable with these events will result in errors as columns named like `count_condition-click` will be generated.

I found this issue that was related (https://github.com/Velir/dbt-ga4/issues/211)

## Checklist
- [x] I have verified that these changes work locally
  - I'm using this exact same function but I'm trying to migrate to a more robust framework
- [x] I have updated the README.md (if applicable)
  - I don't think there's a need?
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
