### PR TITLE
Support for Custom Item Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ vars:
       - name: "country_code"
         value_type: "int_value"
 ```
+### Custom Item Parameters
+
+If you are capturing custom parameters at the item level (within items.item_params), you can specify these parameters and make them available in the `stg_ga4__event_items` model. This uses a similar syntax as the "Custom Parameters" feature described above:
+
+```
+vars:
+  ga4:
+    custom_item_parameters:
+      - name: "item_variant_color"
+        value_type: "string_value"
+        rename_to: "color"
+```
 
 ### User Properties
 

--- a/macros/stage_custom_parameters.sql
+++ b/macros/stage_custom_parameters.sql
@@ -4,3 +4,8 @@
     {% endfor %}
 {% endmacro %}
 
+{% macro stage_custom_item_parameters(custom_item_parameters) %}
+    {% for cip in custom_item_parameters %}
+        ,{{ ga4.unnest_key('i.item_params',  cp.name ,  cp.value_type, cp.rename_to or "default" ) }}
+    {% endfor %}
+{% endmacro %}

--- a/models/staging/stg_ga4__event_items.sql
+++ b/models/staging/stg_ga4__event_items.sql
@@ -1,35 +1,38 @@
 with items_with_params as (
     select
         event_key,
-        event_name,
-        event_date_dt,
-        stream_id,
-        i.item_id,
-        i.item_name,
-        i.item_brand,
-        i.item_variant,
-        i.item_category,
-        i.item_category2,
-        i.item_category3,
-        i.item_category4,
-        i.item_category5,
-        i.price_in_usd,
-        i.price,
-        i.quantity,
-        i.item_revenue_in_usd,
-        i.item_revenue,
-        i.item_refund_in_usd,
-        i.item_refund,
-        i.coupon,
-        i.affiliation,
-        i.location_id,
-        i.item_list_id,
-        i.item_list_name,
-        i.item_list_index,
-        i.promotion_id,
-        i.promotion_name,
-        i.creative_name,
-        i.creative_slot
+        , event_name
+        , event_date_dt
+        , stream_id
+        , i.item_id
+        , i.item_name
+        , i.item_brand
+        , i.item_variant
+        , i.item_category
+        , i.item_category2
+        , i.item_category3
+        , i.item_category4
+        , i.item_category5
+        , i.price_in_usd
+        , i.price
+        , i.quantity
+        , i.item_revenue_in_usd
+        , i.item_revenue
+        , i.item_refund_in_usd
+        , i.item_refund
+        , i.coupon
+        , i.affiliation
+        , i.location_id
+        , i.item_list_id
+        , i.item_list_name
+        , i.item_list_index
+        , i.promotion_id
+        , i.promotion_name
+        , i.creative_name
+        , i.creative_slot
+      {% if var("custom_item_parameters", "none") != "none" %}
+        {{ ga4.stage_custom_item_parameters( var("custom_item_parameters") )}}
+      {% endif %}
     from {{ref('stg_ga4__events')}},
         unnest(items) as i
     where event_name in ('add_payment_info', 'add_shipping_info', 'add_to_cart','add_to_wishlist','begin_checkout' ,'purchase','refund', 'remove_from_cart','select_item', 'select_promotion','view_item_list','view_promotion', 'view_item')


### PR DESCRIPTION
## Description & motivation
This PR provides support for custom item parameters using a project variable of `custom_item_parameters` Ex:

```
vars:
  ga4:
    custom_item_parameters:
      - name: "item_variant_color"
        value_type: "string_value"
        rename_to: "color"
```

custom item parameters are exposed in the `stg_ga4__event_items` model, only. 

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
