### PR TITLE
Improve google-cpc detection

### DIFF
--- a/models/staging/stg_ga4__events.sql
+++ b/models/staging/stg_ga4__events.sql
@@ -33,12 +33,30 @@ detect_gclid as (
     select
         * except (event_source, event_medium, event_campaign),
         case
-            when (page_location like '%gclid%' and event_source is null) then "google"
+            when (
+                page_location like '%gclid%' 
+                and (
+                    event_source is null
+                    or event_source like '%safeframe.googlesyndication.com%'
+                    or event_source like '%doubleclick.net%'
+                )
+            ) then "google"
             else event_source
         end as event_source,
         case
             when (page_location like '%gclid%' and event_medium is null) then "cpc"
+
             when (page_location like '%gclid%' and event_medium = 'organic') then "cpc"
+
+            when (
+                page_location like '%gclid%' 
+                and (
+                    event_source is null
+                    or event_source like '%safeframe.googlesyndication.com%'
+                    or event_source like '%doubleclick.net%'
+                )
+                and event_medium = 'referral'
+            ) then "cpc"
             else event_medium
         end as event_medium,
         case


### PR DESCRIPTION
Some google/cpc visits appear in BigQuery as referrals from either safeframe.googlesyndication.com or doubleclick.net. This update handles those conditions.

## Description & motivation
<!---
Some google/cpc visits appear in BigQuery as referrals from either safeframe.googlesyndication.com or doubleclick.net. This update handles those conditions.
-->

## Checklist
- [X] I have verified that these changes work locally
- [X] I have updated the README.md (if applicable)
- [X] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
