### PR TITLE
Query string all

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ vars:
     query_parameter_exclusions: ["gclid","fbclid","_ga"] 
 ```
 
+You can remove all query parameters by setting `query_parameter_exclusions` to `*all*`.
+
+```
+vars:
+  ga4:
+    query_parameter_exclusions: ["*all*"]
+```
+
 ### Query Parameter Extraction
 
 Setting `query_parameter_extraction` will extract query string parameters from the `page_location` field into new columns. This can be used to extract advertising click IDs into columns that can be joined with advertising data sets. Ex:

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ vars:
     query_parameter_exclusions: ["*all*"]
 ```
 
+By default, parameters are removed from URL fragments (elements after the hash # symbol). If you wish to exclude query parameters but keep URL fragments with the same key, you will need to override the `remove_query_parameters` macro.
+
 ### Query Parameter Extraction
 
 Setting `query_parameter_extraction` will extract query string parameters from the `page_location` field into new columns. This can be used to extract advertising click IDs into columns that can be joined with advertising data sets. Ex:

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -10,7 +10,7 @@
 {% if "*all*" in parameters %}
     regexp_replace({{url}}, r'(\?|&|#).*', '')
 {% else %}
-REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{ parameters|join("|") }})=[^&]*', '\\1'), '\\?&+', '?'), '&+', '&'), '\\?$|&$', '')
+    regexp_replace({{ url }}, r'([&|#|\?]{1}{{ parameters|join("|") }}=[^\?&#]*)', '')
 {% endif %}
 {% endmacro %}
 

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -6,7 +6,11 @@
     REGEXP_EXTRACT({{ url }}, '\\?(.+)')
 {% endmacro %}
 
-{% macro remove_query_parameters(url, parameters)%}
+{% macro remove_query_parameters(url, parameters) %}
+  {{ return(adapter.dispatch('remove_query_parameters', 'ga4')(url, parameters)) }}
+{% endmacro %}
+
+{% macro default__remove_query_parameters(url, parameters)%}
 {% if "*all*" in parameters %}
     regexp_replace({{url}}, r'(\?|&|#).*', '')
 {% else %}

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -10,7 +10,7 @@
 {% if "*all*" in parameters %}
     regexp_replace({{url}}, r'(\?|&|#).*', '')
 {% else %}
-    regexp_replace({{ url }}, r'([&|#|\?]{1}{{ parameters|join("|") }}=[^\?&#]*)', '')
+    regexp_replace({{ url }}, r'([&|#|\?]{1}({{ parameters|join("|") }})=[^\?&#]*)', '')
 {% endif %}
 {% endmacro %}
 

--- a/macros/url_parsing.sql
+++ b/macros/url_parsing.sql
@@ -7,7 +7,11 @@
 {% endmacro %}
 
 {% macro remove_query_parameters(url, parameters)%}
+{% if "*all*" in parameters %}
+    regexp_replace({{url}}, r'(\?|&|#).*', '')
+{% else %}
 REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE(REGEXP_REPLACE({{url}}, '(\\?|&)({{ parameters|join("|") }})=[^&]*', '\\1'), '\\?&+', '?'), '&+', '&'), '\\?$|&$', '')
+{% endif %}
 {% endmacro %}
 
 {% macro extract_page_path(url) %}

--- a/models/staging/stg_ga4__events.yml
+++ b/models/staging/stg_ga4__events.yml
@@ -29,14 +29,17 @@ unit_tests:
           - {page_location: https://asite.com/page?parameter=this_param,    page_referrer: https://asite.com/previous_page?parameter=previous_value}
           - {page_location: https://asite.com/anotherpage?parameter=param%20with%20encoded%20spaces,    page_referrer: https://asite.com/previous_page?utm_source=source_value}
           - {page_location: https://anothersite.com/page?not_excluded_param=val&parameter=someval&param=also_not_excluded, page_referrer: https://anothersite.com/previous_page#utm_source=source_value#parameter=previous_value#hash=hash_value}
+          - {page_location: https://twoparams.com/page&parameter=someval&second_param=1value, page_referrer: https://twoparams.com/previous_page?second_param=a_value#parameter=previous_value#hash=hash_value}
     overrides:
       vars:
-        query_parameter_exclusions: ["parameter"]
+        query_parameter_exclusions: ["parameter","second_param"]
     expect:
       rows:
         - {page_location: https://asite.com/page,    page_referrer: https://asite.com/previous_page}
         - {page_location: https://asite.com/anotherpage,    page_referrer: https://asite.com/previous_page?utm_source=source_value}
         - {page_location: https://anothersite.com/page?not_excluded_param=val&param=also_not_excluded, page_referrer: https://anothersite.com/previous_page#utm_source=source_value#hash=hash_value}
+        - {page_location: https://twoparams.com/page, page_referrer: https://twoparams.com/previous_page#hash=hash_value}
+
   - name: query_parameter_remove_all
     description: "Check that the '*all*' flag removes all query parameters from the model."
     model: stg_ga4__events

--- a/models/staging/stg_ga4__events.yml
+++ b/models/staging/stg_ga4__events.yml
@@ -28,13 +28,15 @@ unit_tests:
         rows:
           - {page_location: https://asite.com/page?parameter=this_param,    page_referrer: https://asite.com/previous_page?parameter=previous_value}
           - {page_location: https://asite.com/anotherpage?parameter=param%20with%20encoded%20spaces,    page_referrer: https://asite.com/previous_page?utm_source=source_value}
+          - {page_location: https://anothersite.com/page?not_excluded_param=val&parameter=someval&param=also_not_excluded, page_referrer: https://anothersite.com/previous_page#utm_source=source_value#parameter=previous_value#hash=hash_value}
     overrides:
       vars:
-        remove_query_string: ["parameter"]
+        query_parameter_exclusions: ["parameter"]
     expect:
       rows:
         - {page_location: https://asite.com/page,    page_referrer: https://asite.com/previous_page}
         - {page_location: https://asite.com/anotherpage,    page_referrer: https://asite.com/previous_page?utm_source=source_value}
+        - {page_location: https://anothersite.com/page?not_excluded_param=val&param=also_not_excluded, page_referrer: https://anothersite.com/previous_page#utm_source=source_value#hash=hash_value}
   - name: query_parameter_remove_all
     description: "Check that the '*all*' flag removes all query parameters from the model."
     model: stg_ga4__events
@@ -45,7 +47,7 @@ unit_tests:
           - {page_location: https://asite.com/anotherpage?parameter=param%20with%20encoded%20spaces,    page_referrer: https://asite.com/previous_page?utm_source=source_value}
     overrides:
       vars:
-        remove_query_string: ["*all*"]
+        query_parameter_exclusions: ["*all*"]
     expect:
       rows:
         - {page_location: https://asite.com/page,    page_referrer: https://asite.com/previous_page}

--- a/models/staging/stg_ga4__events.yml
+++ b/models/staging/stg_ga4__events.yml
@@ -18,3 +18,35 @@ models:
           the data shows that this is not always the case. When a user_engagement event does not fire, the engagement_time_msec parameter is assigned to the next page_view. 
           This engagement time should be credited to the previous page, 
           so for page_view events this field uses the session_key and page_referrer as the key while all other events use the session_key and page_location.
+
+unit_tests:
+  - name: query_parameter_removal
+    description: "Check that query parameters get removed from the model."
+    model: stg_ga4__events
+    given:
+      - input: ref('base_ga4__events')
+        rows:
+          - {page_location: https://asite.com/page?parameter=this_param,    page_referrer: https://asite.com/previous_page?parameter=previous_value}
+          - {page_location: https://asite.com/anotherpage?parameter=param%20with%20encoded%20spaces,    page_referrer: https://asite.com/previous_page?utm_source=source_value}
+    overrides:
+      vars:
+        remove_query_string: ["parameter"]
+    expect:
+      rows:
+        - {page_location: https://asite.com/page,    page_referrer: https://asite.com/previous_page}
+        - {page_location: https://asite.com/anotherpage,    page_referrer: https://asite.com/previous_page?utm_source=source_value}
+  - name: query_parameter_remove_all
+    description: "Check that the '*all*' flag removes all query parameters from the model."
+    model: stg_ga4__events
+    given:
+      - input: ref('base_ga4__events')
+        rows:
+          - {page_location: https://asite.com/page?parameter=this_param,    page_referrer: https://asite.com/previous_page?parameter=previous_value}
+          - {page_location: https://asite.com/anotherpage?parameter=param%20with%20encoded%20spaces,    page_referrer: https://asite.com/previous_page?utm_source=source_value}
+    overrides:
+      vars:
+        remove_query_string: ["*all*"]
+    expect:
+      rows:
+        - {page_location: https://asite.com/page,    page_referrer: https://asite.com/previous_page}
+        - {page_location: https://asite.com/anotherpage,    page_referrer: https://asite.com/previous_page}


### PR DESCRIPTION
## Description & motivation
Initially, I wanted to add an `*all*` flag to the remove query string feature.

When writing the tests, I discovered that the remove query string only removed question and ampersand query strings but not hash strings which may not technically be query strings but are sometimes used as such. 

In fixing the regular expression, I ended up simplifying it and added tests to ensure that the new regex works as expected.

We may want to add the following to the release notes when pushing this live.

> The `query_parameter_exclusions` variable now removes fragments, hash `#` parameters, from `page_location` and `page_referrer`. In most cases this will be an improvement in functionality. However, if you have query parameter keys using question mark, `?`, or ampersand, `&`, that you want to remove and fragments that you don't want to remove, then you will need to override the `remove_query_parameters` macro.

## Checklist
- [y ] I have verified that these changes work locally
- [y ] I have updated the README.md (if applicable)
- [y ] I have added tests & descriptions to my models (and macros if applicable)
- [y ] I have run `dbt test` and `python -m pytest .` to validate existing tests
