### PR TITLE
Issue #340 fill null event key

### DIFF
--- a/models/staging/stg_ga4__events.sql
+++ b/models/staging/stg_ga4__events.sql
@@ -22,11 +22,16 @@ include_session_partition_key as (
         CONCAT(session_key, CAST(event_date_dt as STRING)) as session_partition_key
     from include_session_key
 ),
--- Add unique key for events
+-- Add unique key for events. Potential to not be unique if session_key is null and uniqueness depends on differentiation by that value.
 include_event_key as (
     select 
         *,
-        to_base64(md5(CONCAT(session_key, event_name, CAST(event_timestamp as STRING), to_json_string(event_params)))) as event_key -- Surrogate key for unique events.  
+        to_base64(md5(ARRAY_TO_STRING([
+            session_key,
+            event_name,
+            CAST(event_timestamp as STRING),
+            to_json_string(event_params)
+        ], ""))) as event_key -- Surrogate key for unique events.  
     from include_session_partition_key
 ),
 detect_gclid as (

--- a/models/staging/stg_ga4__events.sql
+++ b/models/staging/stg_ga4__events.sql
@@ -22,7 +22,7 @@ include_session_partition_key as (
         CONCAT(session_key, CAST(event_date_dt as STRING)) as session_partition_key
     from include_session_key
 ),
--- Add unique key for events. Potential to not be unique if session_key is null and uniqueness depends on differentiation by that value.
+-- Add unique key for events. Potential to not be unique if client_key or session_id is null and uniqueness depends on differentiation by that value.
 include_event_key as (
     select 
         *,

--- a/models/staging/stg_ga4__events.sql
+++ b/models/staging/stg_ga4__events.sql
@@ -27,7 +27,8 @@ include_event_key as (
     select 
         *,
         to_base64(md5(ARRAY_TO_STRING([
-            session_key,
+            client_key,
+            CAST(session_id as STRING),
             event_name,
             CAST(event_timestamp as STRING),
             to_json_string(event_params)

--- a/models/staging/stg_ga4__events.sql
+++ b/models/staging/stg_ga4__events.sql
@@ -22,16 +22,11 @@ include_session_partition_key as (
         CONCAT(session_key, CAST(event_date_dt as STRING)) as session_partition_key
     from include_session_key
 ),
--- Add unique key for events. Potential to not be unique if session_key is null and uniqueness depends on differentiation by that value.
+-- Add unique key for events
 include_event_key as (
     select 
         *,
-        to_base64(md5(ARRAY_TO_STRING([
-            session_key,
-            event_name,
-            CAST(event_timestamp as STRING),
-            to_json_string(event_params)
-        ], ""))) as event_key -- Surrogate key for unique events.  
+        to_base64(md5(CONCAT(session_key, event_name, CAST(event_timestamp as STRING), to_json_string(event_params)))) as event_key -- Surrogate key for unique events.  
     from include_session_partition_key
 ),
 detect_gclid as (

--- a/models/staging/stg_ga4__events.yml
+++ b/models/staging/stg_ga4__events.yml
@@ -7,6 +7,9 @@ models:
       - name: client_key
         description: Surrogate key created from stream_id and user_pseudo_id. Provides a way to uniquely identify a user's device within a stream. Important when using the package to combine data across properties and streams.
       - name: event_key
+        description: >
+          Surrogate key for events. Potential for uniqueness test to fail if session_key is null and uniqueness 
+          depends on differentiation by that value.
         tests:
           - unique
       - name: page_path

--- a/models/staging/stg_ga4__events.yml
+++ b/models/staging/stg_ga4__events.yml
@@ -8,8 +8,8 @@ models:
         description: Surrogate key created from stream_id and user_pseudo_id. Provides a way to uniquely identify a user's device within a stream. Important when using the package to combine data across properties and streams.
       - name: event_key
         description: >
-          Surrogate key for events. Potential for uniqueness test to fail if session_key is null and uniqueness 
-          depends on differentiation by that value.
+          Surrogate key for events. Potential for uniqueness test to fail if client_key or session_id is null
+          and uniqueness depends on differentiation by that value.
         tests:
           - unique
       - name: page_path


### PR DESCRIPTION
## Description & motivation
Follows discussion in Issue #340 
### Changes:
* Use array_to_string rather than concat to create event_key
* replace session_key with client_key and session_id in event_key creation
* Add warning for users that this could result in duplicate event_keys in cases where distinction between events depends on one or both of those values being not null.

### Rationale:
Generate event_key even when session_key is null (either because of null user_psuedo_id or null ga_session_id). This will improve the usability of event_key as a tool to count unique events. 

Use both client_key and session_id in key creation (instead of session_key) so that a null value in either user_pseudo_id or ga_session_id will not nullify the other. This prevents duplicate event_keys. For example:
- In a case where user_pseudo_id is available but ga_session_id is null. This results in a null session_key. If that session_key is used to create event_key for two events for which all other inputs to key generation are identical then there will be duplicates. Using both client_key and session_id in event_key generation prevents this.
- Of course in the case that both user_pseudo_id and ga_session_id are null and all other inputs to key generation are identical there will still be duplicates.

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
