### PR TITLE
partition macro

### DIFF
--- a/macros/partition_via_information_schema.sql
+++ b/macros/partition_via_information_schema.sql
@@ -1,0 +1,47 @@
+{% macro get_max_date_partition( target_table ) %}
+    {% set sql -%}
+        select 
+            max(partition_id)
+        from {{target.project}}.{{target.dataset}}.INFORMATION_SCHEMA.PARTITIONS
+        where table_name = '{{target_table}}'
+    {%- endset %}
+    {{ print('Run query get_max_date_partition') }}
+    {% set results = run_query(sql) %}
+
+    {% if execute %}
+        {# Return the first column #}
+        {{ print('Execute get_max_date_partition') }}
+        {% set results_list = results.columns[0].values() %}
+    {% else %}
+        {% set results_list = [] %}
+    {% endif %}
+    {# Query only returns a single value so get the first value #}
+    {{ return(results_list[0]) }}
+{% endmacro %}
+{# Source is the next upstream, partitioned model (views won't work) #}
+{% macro get_updated_since_last_modified( source_project, source_dataset, source_table, max_date_partition ) %}
+    {{ print('max_date_partition: ' + max_date_partition) }}
+    {% set sql -%}
+        select 
+            -- need to extract shard identifier from table_name for sharded tables
+            -- assuming that non-partitioned tables are sharded; would be nice to detect view vs sharded
+            min(case when partition_id is null then right(table_name, 8) else partition_id end) as min_partition
+            -- could potentially get all partitions instead of min_partition and then use a where in list(partitions) condition
+        from {{source_project}}.{{source_dataset}}.INFORMATION_SCHEMA.PARTITIONS
+        where table_name = '{{source_table}}'
+        and last_modified_time >= timestamp(parse_date( '%Y%m%d' , cast({{max_date_partition}} as string))) 
+    {%- endset %}
+    {{ print('Run query get_updated_since_last_modified') }}
+    {% set results = run_query(sql) %}
+    {% if execute %}
+        {# Return the first column #}
+        {{ print('Execute get_updated_since_last_modified') }}
+        {% set results_list = results.columns[0].values() %}
+    {% else %}
+        {% set results_list = [] %}
+    {% endif %}
+    {# Need to add logic for when nothing matches #}
+    {{ print('Return get_updated_since_last_modified: ' + results_list[0]) }}
+    {# Query only returns a single value so get the first value #}
+    {{ return(results_list[0]) }}
+{% endmacro %}


### PR DESCRIPTION
## Description & motivation
This is a work-in-progress POC of using the `INFORMATION_SCHEMA` schema tables to find what was the last partition updated, checking source tables to see if they have been updated since the last update ran, and then only update partitions that have modifications. 

It is intended to replace `static_incremental_days` but is currently only shared for the purpose of discussion.

The initial version should work with sharded and partitioned tables. 

The macros is meant to be called at the top of partitioned models:

```
{% if is_incremental() %}
    {% set max_partition = get_max_date_partition( 'fct_ga4__event_page_view' ) %}
    {% set min_modified_partition = get_updated_since_last_modified( {{var('source_project')}} , 'source_dataset' , 'base_ga4__events', max_partition  ) %}
{% endif %}
```
And then when partition-pruning:

```
{% if is_incremental() %}
    where event_date_dt >= parse_date( '%Y%m%d' ,cast({{min_modified_partition }} as string))
{% endif %}
```

## To-Do
- multi-site
- stop models from running when there are no matching partitions (haven't tested how this works as it is only applicable to daily sync with no streaming and my test environment has streaming enabled so there are always matching updates)
- maybe we want to consolidate the query somehow so that we only check if the `base_ga4__events` has been modified once and then process all downstream models equally

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
