### PR TITLE
Remove the unused `unpack_struct` macro

### DIFF
--- a/macros/unpack_struct.sql
+++ b/macros/unpack_struct.sql
@@ -1,5 +1,0 @@
-{%- macro unpack_struct(column_to_unpack, fields) -%}
-{% for field in fields %}
-{{column_to_unpack}}.{{field}} as {{column_to_unpack}}_{{field}} {% if not loop.last %},{% endif %}
-{% endfor %}
-{%- endmacro -%}


### PR DESCRIPTION
## Description & motivation
<!---
Describe your changes, and why you're making them.
-->

Since the `unpack_struct` macro is not called anywhere in the current codebase, I have determined that it is unnecessary.

## Checklist
- [ ] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
