### PR TITLE
Filter partitions on test `unique_stg_ga4__events_event_key`

### DIFF
--- a/models/staging/stg_ga4__events.yml
+++ b/models/staging/stg_ga4__events.yml
@@ -11,7 +11,9 @@ models:
           Surrogate key for events. Potential for uniqueness test to fail if client_key or session_id is null
           and uniqueness depends on differentiation by that value.
         tests:
-          - unique
+          - unique:
+              config:
+                where: event_date_dt > date_sub(current_date(), interval 7 day)
       - name: page_path
         description: This field contains the page_location with the query string portion removed. Uses macro remove_query_string
       - name: page_engagement_key


### PR DESCRIPTION
Reduce compute by limiting the test `unique_stg_ga4__events_event_key` to the last 7 days (`event_timestamp` is already in the hash so no need to test all partitions)

## Description & motivation
By default the unique_stg_ga4__events_event_key test scans all partitions which can be very expensive, at 2TB in this example:

<img width="537" alt="SCR-20250508-lpzr" src="https://github.com/user-attachments/assets/a688c4e0-4b1e-4e62-9bd4-959aac81ff9c" />

Scanning all partitions is not required as the event_key already includes the event timestamp.
The same test on the same data is 100 times less expensive at 22GB when adding a partition filter on the last 7 days.

<img width="977" alt="SCR-20250508-lqwc" src="https://github.com/user-attachments/assets/5810e958-7656-4a9e-a4e1-0ab91831576b" />


## Checklist
- [x] I have verified that these changes work locally
- [x] I have updated the README.md (if applicable)
- [x] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` to validate existing tests
- [ ] I have run `python -m pytest .` to validate existing tests

For a reason I can't explain most integration test are failing with FileNotFoundError despite being in the unit_tests directory, existing files in other directories, and being able to view the file find the file on direct executions like `python -c "from dbt.tests.util import read_file; print(read_file('../macros/default_channel_grouping.sql'))"`

ERROR test_macro_default_channel_grouping.py::TestDefaultChannelGrouping::test_mock_run_and_check - FileNotFoundError: [Errno 2] No such file or directory: '../macros/default_channel_grouping.sql'
[... 8 others]
========================================================== 4 passed, 141 warnings, 9 errors in 70.85s (0:01:10) ==========================================================