### PR TITLE
Fixing typos in base model yml property 'description'

### DIFF
--- a/models/staging/base/base_ga4__pseudonymous_users.yml
+++ b/models/staging/base/base_ga4__pseudonymous_users.yml
@@ -82,4 +82,4 @@ models:
       - name: occurence_date
         description: Date when the record change was triggered. This is the partitioning column.
       - name: last_updated_date
-        desctiption: Date when the record was updated in the table.
+        description: Date when the record was updated in the table.

--- a/models/staging/base/base_ga4__users.yml
+++ b/models/staging/base/base_ga4__users.yml
@@ -80,4 +80,4 @@ models:
       - name: occurence_date
         description: Date when the record change was triggered. This is the partitioning column.
       - name: last_updated_date
-        desctiption: Date when the record was updated in the table.
+        description: Date when the record was updated in the table.


### PR DESCRIPTION
## Typos in base model ymls for last_updated_date "description"s
<!---
Changed "desctiption" to correct "description" property name for columns in base_ga4__pseudonymous_users.yml, base_ga4__users.yml, correcting warning thrown at runtime.
-->

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [x] I have run `dbt test` and `python -m pytest .` to validate existing tests
