### PR TITLE
Fix YAML, doc, and column alias typos in user export models

### DIFF
--- a/macros/base_select.sql
+++ b/macros/base_select.sql
@@ -201,7 +201,7 @@
     , device.category as device_category
     , device.mobile_brand_name as device_mobile_brand_name
     , device.mobile_model_name as device_mobile_model_name
-    , device.unified_screen_name as device_unified_sceen_name
+    , device.unified_screen_name as device_unified_screen_name
     , geo.city as geo_city 
     , geo.country as geo_country 
     , geo.continent as geo_continent 

--- a/models/staging/base/base_ga4__pseudonymous_users.yml
+++ b/models/staging/base/base_ga4__pseudonymous_users.yml
@@ -5,7 +5,7 @@ models:
     description: >
       Base pseudo-user (client) model that pulls all fields from the pseudonymous user table of the user export. The pseudonymous user table is keyed on 
       the user_pseudo_id which is the cid parameter in Gtag calls and is the main parameter in the from which the dbt-GA4 client_id is
-      created. The table is partitioned by occurence_date. This model also flattens some fields.
+      created. The table is partitioned by occurrence_date. This model also flattens some fields.
     columns:
       - name: pseudo_user_id
         description: >
@@ -28,7 +28,7 @@ models:
         description: Flattened version of device.mobile_brand_name.
       - name: device_mobile_model_name
         description: Flattened version of device.mobile_model_name.
-      - name: device_unified_sceen_name
+      - name: device_unified_screen_name
         description: Flattened version of device.unified_screen_name.
       - name: geo_city
         description: Flattened version of geo.city.
@@ -53,7 +53,7 @@ models:
       - name: predictions_in_app_purchase_score_7d
         description: >
             Probability that a user who was active in the last 28 days will log an in_app_purchase event within the next 7 days. 
-            Flattened ersion of predictions.in_app_purchase_score_7d.
+            Flattened version of predictions.in_app_purchase_score_7d.
       - name: predictions_purchase_score_7d
         description: >
             Probability that a user who was active in the last 28 days will log a purchase event within the next 7 days. 
@@ -79,7 +79,7 @@ models:
             because, in the most general case, some of the '(not set)' rows will include users that are not eligible for ads personalization. Users where 
             isAdsPersonalizationAllowed = 'false' may still be used for non-advertising use cases like A/B testing & data explorations. Flattened version of 
             privacy_info.is_ads_personalization_allowed.
-      - name: occurence_date
+      - name: occurrence_date
         description: Date when the record change was triggered. This is the partitioning column.
       - name: last_updated_date
-        desctiption: Date when the record was updated in the table.
+        description: Date when the record was updated in the table.

--- a/models/staging/base/base_ga4__users.yml
+++ b/models/staging/base/base_ga4__users.yml
@@ -5,7 +5,7 @@ models:
     description: >
       Base user model that pulls all fields from the pseudonymous user table of the user export. The pseudonymous user table is keyed on 
       the user_pseudo_id which is the cid parameter in Gtag calls and is the main parameter in the from which the dbt-GA4 client_key is
-      created. The table is partitioned by occurence_date. This model also flattens some fields.
+      created. The table is partitioned by occurrence_date. This model also flattens some fields.
     columns:
       - name: pseudo_user_id
         description: >
@@ -26,7 +26,7 @@ models:
         description: Flattened version of device.mobile_brand_name.
       - name: device_mobile_model_name
         description: Flattened version of device.mobile_model_name.
-      - name: device_unified_sceen_name
+      - name: device_unified_screen_name
         description: Flattened version of device.unified_screen_name.
       - name: geo_city
         description: Flattened version of geo.city.
@@ -51,7 +51,7 @@ models:
       - name: predictions_in_app_purchase_score_7d
         description: >
             Probability that a user who was active in the last 28 days will log an in_app_purchase event within the next 7 days. 
-            Flattened ersion of predictions.in_app_purchase_score_7d.
+            Flattened version of predictions.in_app_purchase_score_7d.
       - name: predictions_purchase_score_7d
         description: >
             Probability that a user who was active in the last 28 days will log a purchase event within the next 7 days. 
@@ -77,7 +77,7 @@ models:
             because, in the most general case, some of the '(not set)' rows will include users that are not eligible for ads personalization. Users where 
             isAdsPersonalizationAllowed = 'false' can still be used for non-advertising use cases like A/B testing & data explorations. Flattened version of 
             privacy_info.is_ads_personalization_allowed.
-      - name: occurence_date
+      - name: occurrence_date
         description: Date when the record change was triggered. This is the partitioning column.
       - name: last_updated_date
-        desctiption: Date when the record was updated in the table.
+        description: Date when the record was updated in the table.

--- a/models/staging/stg_ga4__client_keys.yml
+++ b/models/staging/stg_ga4__client_keys.yml
@@ -65,7 +65,7 @@ as membership_expiry_timestamp_micros, true as npa)']
             , 321.0 as predictions_revenue_28d_in_usd
             , false as privacy_info_is_limited_ad_tracking
             , false as privacy_info_is_ads_personalization_allowed
-            , date('2024-12-10') as occurence_date
+            , date('2024-12-10') as occurrence_date
             , date('2024-12-12') as last_updated_date 
             , array[
               struct(
@@ -120,7 +120,7 @@ as membership_expiry_timestamp_micros, true as npa)']
             , 321.0 as predictions_revenue_28d_in_usd
             , false as privacy_info_is_limited_ad_tracking
             , false as privacy_info_is_ads_personalization_allowed
-            , date('2024-12-10') as occurence_date
+            , date('2024-12-10') as occurrence_date
             , date('2024-12-12') as last_updated_date 
             , array[
               struct(

--- a/models/staging/stg_ga4__users.yml
+++ b/models/staging/stg_ga4__users.yml
@@ -64,7 +64,7 @@ as membership_expiry_timestamp_micros, true as npa)']
             , 321.0 as predictions_revenue_28d_in_usd
             , false as privacy_info_is_limited_ad_tracking
             , false as privacy_info_is_ads_personalization_allowed
-            , date('2024-12-10') as occurence_date
+            , date('2024-12-10') as occurrence_date
             , date('2024-12-12') as last_updated_date 
             , array[
               struct(
@@ -118,7 +118,7 @@ as membership_expiry_timestamp_micros, true as npa)']
             , 321.0 as predictions_revenue_28d_in_usd
             , false as privacy_info_is_limited_ad_tracking
             , false as privacy_info_is_ads_personalization_allowed
-            , date('2024-12-10') as occurence_date
+            , date('2024-12-10') as occurrence_date
             , date('2024-12-12') as last_updated_date 
             , array[
               struct(


### PR DESCRIPTION
## Description & motivation

Fixes several typos in the user export base models that cause silent metadata loss or dbt parse warnings in downstream projects.

| Typo | Location | Impact |
|------|----------|--------|
| `desctiption:` → `description:` | `base_ga4__users.yml`, `base_ga4__pseudonymous_users.yml` | Unrecognized YAML key drops `last_updated_date` docs; triggers `UnusedConfigKey (dbt1060)` / `PackageParsingCompatibility (dbt1065)` on every parse in dbt Fusion |
| `occurence_date` → `occurrence_date` | Base YAML + unit test fixtures | Aligns docs/fixtures with actual SQL output (`occurrence_date` in `base_select.sql`) |
| `device_unified_sceen_name` → `device_unified_screen_name` | `base_select.sql` macro + base YAML | Fixes column alias typo; **breaking rename** for anyone selecting the old column name |
| `Flattened ersion` → `Flattened version` | Base YAML descriptions | Cosmetic |

Supersedes #397 — that PR only fixed one of the two `desctiption` occurrences.

Same class of fix as #385 (`Clint` → `Client`).

## Breaking change note

Renaming `device_unified_sceen_name` → `device_unified_screen_name` changes the output column name on `base_ga4__users` / `base_ga4__pseudonymous_users` (and downstream models that pass it through). Happy to split that into a separate PR if maintainers prefer a YAML-only release first.

## Checklist

- [x] Verified changes are limited to typo corrections in YAML, docs, and one column alias
- [ ] Ran `dbt test` and `python -m pytest .` — not run locally (YAML/SQL alias only; no logic changes)


Made with [Cursor](https://cursor.com)